### PR TITLE
Refresh AI infra landscape with maintainable SVG pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2025-10-29
+last_updated: 2026-03-13
 tags: ai-infrastructure, kubernetes, learning-path, landscape
 ---
 
@@ -25,14 +25,18 @@ This landscape visualizes key components across the AI Infrastructure stack, map
 
 The goal is to demystify the evolving AI Infra stack and guide engineers on where to focus their learning.
 
-## 📊 AI-Infra Landscape (2025 June, needs an update)
+## 📊 AI-Infra Landscape (2026 March)
 
 **Legend:**
 
 > - Dashed outlines = Early stage or under exploration
 > - Labels on right = Functional categories
 
-![AI-Infra Landscape](./diagrams/ai-infra-landscape.png)
+![AI-Infra Landscape](./diagrams/ai-infra-landscape.svg)
+
+Maintenance:
+- Source data: `./diagrams/ai-infra-landscape.data.json`
+- Generate SVG: `node ./scripts/generate-landscape-svg.js`
 
 ## 🧭 Learning Path for AI Infra Engineers
 
@@ -226,4 +230,3 @@ Apache License 2.0.
 ---
 
 _This repo is inspired by the rapidly evolving AI Infra stack and aims to help engineers navigate and master it._
-

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2025-10-29
+last_updated: 2026-03-13
 tags: repository, structure, documentation, organization
 ---
 
@@ -28,7 +28,8 @@ AI-Infra/
 ├── LICENSE                            # Repository license
 ├── STRUCTURE.md                       # This file - repository organization guide
 ├── diagrams/                          # Centralized image storage
-│   ├── ai-infra-landscape.png        # AI infrastructure landscape visualization
+│   ├── ai-infra-landscape.svg        # AI infrastructure landscape visualization
+│   ├── ai-infra-landscape.data.json  # Source data for generating landscape SVG
 │   └── pod-lifecycle.png             # Kubernetes pod lifecycle diagram
 ├── docs/                              # All documentation content
 │   ├── kubernetes/                   # Kubernetes and scheduling topics
@@ -125,7 +126,7 @@ All images referenced by documentation files are stored here:
 - Flowcharts (pod lifecycle)
 - Reference images
 
-**Reference Pattern**: `../../diagrams/image-name.png` from doc files
+**Reference Pattern**: `../../diagrams/image-name.svg` (or `.png`) from doc files
 
 ## Metadata Format
 
@@ -258,7 +259,7 @@ Key points:
 Old links are broken after refactoring. Update any external references:
 
 - `./kubernetes/pod-lifecycle.md` → `./docs/kubernetes/pod-lifecycle.md`
-- `./ai-infra-landscape.png` → `./diagrams/ai-infra-landscape.png`
+- `./ai-infra-landscape.svg` → `./diagrams/ai-infra-landscape.svg`
 
 ## Future Enhancements
 

--- a/diagrams/ai-infra-landscape.data.json
+++ b/diagrams/ai-infra-landscape.data.json
@@ -1,0 +1,92 @@
+{
+  "meta": {
+    "title": "AI Infra Landscape",
+    "version": "2026-03",
+    "last_updated": "2026-03-13",
+    "note": "Regenerate diagrams/ai-infra-landscape.svg with node scripts/generate-landscape-svg.js"
+  },
+  "axes": {
+    "x_left": "Prototype / Early-stage",
+    "x_right": "Mature / Standardized",
+    "y_bottom": "Kernel / Runtime Layer",
+    "y_top": "AI / Application Layer"
+  },
+  "quadrants": [
+    { "id": "q1", "label": "App + Emerging", "x": 22, "y": 92 },
+    { "id": "q2", "label": "App + Mature", "x": 74, "y": 92 },
+    { "id": "q3", "label": "Infra + Emerging", "x": 22, "y": 8 },
+    { "id": "q4", "label": "Infra + Mature", "x": 74, "y": 8 }
+  ],
+  "ecosystem": [
+    { "name": "PyTorch", "x": 56, "group": "training" },
+    { "name": "JAX", "x": 63, "group": "training" },
+    { "name": "TensorFlow", "x": 70, "group": "training" },
+    { "name": "MLX", "x": 77, "group": "training" },
+    { "name": "Hugging Face", "x": 85, "group": "inference" },
+    { "name": "DeepSpeed", "x": 91, "group": "training" },
+    { "name": "XGBoost", "x": 97, "group": "training" }
+  ],
+  "right_notes": [
+    { "label": "AI Gateway", "y": 90, "group": "gateway" },
+    { "label": "Workflow", "y": 80, "group": "workflow" },
+    { "label": "Training", "y": 74, "group": "training" },
+    { "label": "Serverless", "y": 68, "group": "workflow" },
+    { "label": "Cloud-native Inference", "y": 65, "group": "inference" },
+    { "label": "Inference", "y": 56, "group": "inference" },
+    { "label": "Scheduling", "y": 46, "group": "scheduling" },
+    { "label": "Orchestration", "y": 20, "group": "kernel" },
+    { "label": "Kernel", "y": 10, "group": "kernel" }
+  ],
+  "groups": {
+    "gateway": { "fill": "#FDF1D2", "stroke": "#D5B062" },
+    "workflow": { "fill": "#FCEFF7", "stroke": "#C87AA0" },
+    "inference": { "fill": "#EAF2FF", "stroke": "#5A88D8" },
+    "scheduling": { "fill": "#EBF8EE", "stroke": "#65A97B" },
+    "kernel": { "fill": "#EEF2FF", "stroke": "#667EEA" },
+    "training": { "fill": "#FFF3E8", "stroke": "#D59B5A" }
+  },
+  "projects": [
+    { "name": "Agent Sandbox", "x": 8, "y": 92, "group": "workflow", "stage": "early", "logo": "AS" },
+    { "name": "kagent", "x": 18, "y": 93, "group": "workflow", "stage": "mature", "logo": "KA" },
+    { "name": "Dagger", "x": 42, "y": 98, "group": "workflow", "stage": "mature", "logo": "DG" },
+    { "name": "Dify", "x": 52, "y": 97, "group": "workflow", "stage": "mature", "logo": "DI" },
+    { "name": "AIBrix", "x": 26, "y": 72, "group": "inference", "stage": "early", "logo": "AB" },
+    { "name": "Dynamo", "x": 33, "y": 68, "group": "inference", "stage": "early", "logo": "DY" },
+    { "name": "llmaz", "x": 21, "y": 66, "group": "inference", "stage": "early", "logo": "LM" },
+    { "name": "rbg", "x": 24, "y": 60, "group": "inference", "stage": "mature", "logo": "RB" },
+    { "name": "kthena", "x": 25, "y": 55, "group": "inference", "stage": "mature", "logo": "KT" },
+    { "name": "kubeRay", "x": 36, "y": 58, "group": "inference", "stage": "early", "logo": "KR" },
+    { "name": "Semantic Router", "x": 44, "y": 82, "group": "gateway", "stage": "early", "logo": "SR" },
+    { "name": "Gateway API Inference Extension", "x": 52, "y": 87, "group": "gateway", "stage": "early", "logo": "GA" },
+    { "name": "Envoy AI Gateway", "x": 60, "y": 83, "group": "gateway", "stage": "mature", "logo": "EA" },
+    { "name": "kgateway", "x": 68, "y": 80, "group": "gateway", "stage": "mature", "logo": "KG" },
+    { "name": "knoway", "x": 73, "y": 80, "group": "gateway", "stage": "early", "logo": "KW" },
+    { "name": "Higress", "x": 62, "y": 78, "group": "gateway", "stage": "mature", "logo": "HG" },
+    { "name": "Kong", "x": 66, "y": 76, "group": "gateway", "stage": "mature", "logo": "KO" },
+    { "name": "Istio", "x": 70, "y": 90, "group": "gateway", "stage": "mature", "logo": "IS" },
+    { "name": "KServe", "x": 74, "y": 72, "group": "inference", "stage": "mature", "logo": "KS" },
+    { "name": "Knative", "x": 80, "y": 71, "group": "workflow", "stage": "mature", "logo": "KN" },
+    { "name": "Kubeflow", "x": 90, "y": 75, "group": "training", "stage": "mature", "logo": "KF" },
+    { "name": "Kubeflow Trainer", "x": 92, "y": 70, "group": "training", "stage": "mature", "logo": "KT" },
+    { "name": "SGLang", "x": 45, "y": 55, "group": "inference", "stage": "mature", "logo": "SG" },
+    { "name": "vLLM", "x": 54, "y": 49, "group": "inference", "stage": "mature", "logo": "VL" },
+    { "name": "Triton Inference Server", "x": 56, "y": 42, "group": "inference", "stage": "mature", "logo": "TR" },
+    { "name": "LWS", "x": 34, "y": 50, "group": "scheduling", "stage": "early", "logo": "LW" },
+    { "name": "JobSet", "x": 52, "y": 56, "group": "scheduling", "stage": "early", "logo": "JS" },
+    { "name": "Godel", "x": 22, "y": 40, "group": "scheduling", "stage": "mature", "logo": "GD" },
+    { "name": "Kai Scheduler", "x": 29, "y": 38, "group": "scheduling", "stage": "early", "logo": "KI" },
+    { "name": "Volcano", "x": 39, "y": 36, "group": "scheduling", "stage": "mature", "logo": "VO" },
+    { "name": "Kueue", "x": 66, "y": 42, "group": "scheduling", "stage": "mature", "logo": "KQ" },
+    { "name": "YuniKorn", "x": 79, "y": 43, "group": "scheduling", "stage": "mature", "logo": "YK" },
+    { "name": "Koordinator", "x": 75, "y": 36, "group": "scheduling", "stage": "mature", "logo": "KD" },
+    { "name": "PodRestart", "x": 42, "y": 28, "group": "kernel", "stage": "early", "logo": "PR" },
+    { "name": "ImageVolume", "x": 45, "y": 23, "group": "kernel", "stage": "early", "logo": "IV" },
+    { "name": "DRA", "x": 52, "y": 27, "group": "kernel", "stage": "early", "logo": "DR" },
+    { "name": "NRI", "x": 30, "y": 18, "group": "kernel", "stage": "early", "logo": "NR" },
+    { "name": "Model Spec", "x": 10, "y": 20, "group": "kernel", "stage": "early", "logo": "MS" },
+    { "name": "KWOK", "x": 70, "y": 20, "group": "kernel", "stage": "mature", "logo": "KW" },
+    { "name": "Kubernetes", "x": 90, "y": 18, "group": "kernel", "stage": "mature", "logo": "K8" },
+    { "name": "containerd", "x": 88, "y": 10, "group": "kernel", "stage": "mature", "logo": "CD" },
+    { "name": "KubeVirt", "x": 78, "y": 12, "group": "kernel", "stage": "mature", "logo": "KV" }
+  ]
+}

--- a/diagrams/ai-infra-landscape.data.json
+++ b/diagrams/ai-infra-landscape.data.json
@@ -18,13 +18,13 @@
     { "id": "q4", "label": "Infra + Mature", "x": 74, "y": 8 }
   ],
   "ecosystem": [
-    { "name": "PyTorch", "x": 56, "group": "training" },
-    { "name": "JAX", "x": 63, "group": "training" },
-    { "name": "TensorFlow", "x": 70, "group": "training" },
-    { "name": "MLX", "x": 77, "group": "training" },
-    { "name": "Hugging Face", "x": 85, "group": "inference" },
-    { "name": "DeepSpeed", "x": 91, "group": "training" },
-    { "name": "XGBoost", "x": 97, "group": "training" }
+    { "name": "PyTorch", "x": 56, "group": "training", "logo": "PT" },
+    { "name": "JAX", "x": 63, "group": "training", "logo": "JX" },
+    { "name": "TensorFlow", "x": 70, "group": "training", "logo": "TF" },
+    { "name": "MLX", "x": 77, "group": "training", "logo": "MX" },
+    { "name": "Hugging Face", "x": 85, "group": "inference", "logo": "HF" },
+    { "name": "DeepSpeed", "x": 91, "group": "training", "logo": "DS" },
+    { "name": "XGBoost", "x": 97, "group": "training", "logo": "XG" }
   ],
   "right_notes": [
     { "label": "AI Gateway", "y": 90, "group": "gateway" },

--- a/diagrams/ai-infra-landscape.svg
+++ b/diagrams/ai-infra-landscape.svg
@@ -1,0 +1,442 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1800" height="1150" viewBox="0 0 1800 1150" role="img" aria-labelledby="title desc">
+  <title id="title">AI Infra Landscape (2026-03)</title>
+  <desc id="desc">Four-quadrant AI infra landscape generated from data for easy maintenance.</desc>
+  <defs>
+    <style>
+      .title { font: 700 42px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .subtitle { font: 500 19px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #4b5563; }
+      .axis-label { font: 600 26px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #374151; }
+      .quad-label { font: 600 16px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #6b7280; }
+      .legend { font: 500 15px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #374151; }
+      .project-label { font: 600 14px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .logo { font: 700 10px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #374151; }
+      .ecosystem-label { font: 600 13px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .ecosystem-logo { font: 700 8px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #374151; }
+      .note-label { font: 600 15px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #1f2937; }
+      .project-early rect,
+      .project-early circle { stroke-dasharray: 4 4; }
+      .footer { font: 500 13px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #6b7280; }
+    </style>
+  </defs>
+
+  <rect x="0" y="0" width="1800" height="1150" fill="#f4f5f7" />
+
+  <text x="110" y="52" class="title">AI Infra Landscape</text>
+  <text x="110" y="82" class="subtitle">2026-03 | Last updated 2026-03-13</text>
+
+  <rect x="110" y="130" width="710" height="450" fill="#FBFCFF" />
+  <rect x="820" y="130" width="710" height="450" fill="#FAFDFF" />
+  <rect x="110" y="580" width="710" height="450" fill="#FCFCFD" />
+  <rect x="820" y="580" width="710" height="450" fill="#FBFCFE" />
+
+  <rect x="110" y="130" width="1420" height="900" fill="none" stroke="#1f2937" stroke-width="2" stroke-dasharray="6 5" />
+  <line x1="820" y1="130" x2="820" y2="1030" stroke="#4b5563" stroke-width="2" stroke-dasharray="6 5" />
+  <line x1="110" y1="580" x2="1530" y2="580" stroke="#4b5563" stroke-width="2" stroke-dasharray="6 5" />
+
+  <text x="820" y="106" text-anchor="middle" class="axis-label">AI / Application Layer</text>
+  <text x="820" y="1108" text-anchor="middle" class="axis-label">Kernel / Runtime Layer</text>
+  <text x="92" y="580" text-anchor="end" class="axis-label">Prototype / Early-stage</text>
+  <text x="1548" y="580" class="axis-label">Mature / Standardized</text>
+
+  <text x="422.4" y="202" class="quad-label">App + Emerging</text>
+  <text x="1160.8" y="202" class="quad-label">App + Mature</text>
+  <text x="422.4" y="958" class="quad-label">Infra + Emerging</text>
+  <text x="1160.8" y="958" class="quad-label">Infra + Mature</text>
+
+  <text x="110" y="104" class="legend">Legend: dashed border = early stage / under exploration</text>
+
+  
+    <g class="ecosystem-item" transform="translate(844.2, 58)">
+      <rect x="0" y="0" width="122" height="34" rx="17" fill="#FFF3E8" stroke="#D59B5A" />
+      <circle cx="18" cy="17" r="8" fill="white" stroke="#D59B5A" />
+      <text x="18" y="21" text-anchor="middle" class="ecosystem-logo">P</text>
+      <text x="32" y="22" class="ecosystem-label">PyTorch</text>
+    </g>
+  
+    <g class="ecosystem-item" transform="translate(943.6, 58)">
+      <rect x="0" y="0" width="122" height="34" rx="17" fill="#FFF3E8" stroke="#D59B5A" />
+      <circle cx="18" cy="17" r="8" fill="white" stroke="#D59B5A" />
+      <text x="18" y="21" text-anchor="middle" class="ecosystem-logo">J</text>
+      <text x="32" y="22" class="ecosystem-label">JAX</text>
+    </g>
+  
+    <g class="ecosystem-item" transform="translate(1043.0, 58)">
+      <rect x="0" y="0" width="122" height="34" rx="17" fill="#FFF3E8" stroke="#D59B5A" />
+      <circle cx="18" cy="17" r="8" fill="white" stroke="#D59B5A" />
+      <text x="18" y="21" text-anchor="middle" class="ecosystem-logo">T</text>
+      <text x="32" y="22" class="ecosystem-label">TensorFlow</text>
+    </g>
+  
+    <g class="ecosystem-item" transform="translate(1142.4, 58)">
+      <rect x="0" y="0" width="122" height="34" rx="17" fill="#FFF3E8" stroke="#D59B5A" />
+      <circle cx="18" cy="17" r="8" fill="white" stroke="#D59B5A" />
+      <text x="18" y="21" text-anchor="middle" class="ecosystem-logo">M</text>
+      <text x="32" y="22" class="ecosystem-label">MLX</text>
+    </g>
+  
+    <g class="ecosystem-item" transform="translate(1255.5, 58)">
+      <rect x="0" y="0" width="123" height="34" rx="17" fill="#EAF2FF" stroke="#5A88D8" />
+      <circle cx="18" cy="17" r="8" fill="white" stroke="#5A88D8" />
+      <text x="18" y="21" text-anchor="middle" class="ecosystem-logo">HF</text>
+      <text x="32" y="22" class="ecosystem-label">Hugging Face</text>
+    </g>
+  
+    <g class="ecosystem-item" transform="translate(1341.2, 58)">
+      <rect x="0" y="0" width="122" height="34" rx="17" fill="#FFF3E8" stroke="#D59B5A" />
+      <circle cx="18" cy="17" r="8" fill="white" stroke="#D59B5A" />
+      <text x="18" y="21" text-anchor="middle" class="ecosystem-logo">D</text>
+      <text x="32" y="22" class="ecosystem-label">DeepSpeed</text>
+    </g>
+  
+    <g class="ecosystem-item" transform="translate(1426.4, 58)">
+      <rect x="0" y="0" width="122" height="34" rx="17" fill="#FFF3E8" stroke="#D59B5A" />
+      <circle cx="18" cy="17" r="8" fill="white" stroke="#D59B5A" />
+      <text x="18" y="21" text-anchor="middle" class="ecosystem-logo">X</text>
+      <text x="32" y="22" class="ecosystem-label">XGBoost</text>
+    </g>
+
+  
+    <g class="project project-early" data-name="Agent Sandbox">
+      <rect x="146.6" y="185.0" width="154" height="34" rx="8" fill="#FCEFF7" stroke="#C87AA0" />
+      <circle cx="164.6" cy="202.0" r="11.5" fill="white" stroke="#C87AA0" />
+      <text x="164.6" y="206.2" text-anchor="middle" class="logo">AS</text>
+      <text x="182.6" y="207.0" class="project-label">Agent Sandbox</text>
+    </g>
+  
+    <g class="project" data-name="kagent">
+      <rect x="291.6" y="176.0" width="148" height="34" rx="8" fill="#FCEFF7" stroke="#C87AA0" />
+      <circle cx="309.6" cy="193.0" r="11.5" fill="white" stroke="#C87AA0" />
+      <text x="309.6" y="197.2" text-anchor="middle" class="logo">KA</text>
+      <text x="327.6" y="198.0" class="project-label">kagent</text>
+    </g>
+  
+    <g class="project" data-name="Dagger">
+      <rect x="632.4" y="138.0" width="148" height="34" rx="8" fill="#FCEFF7" stroke="#C87AA0" />
+      <circle cx="650.4" cy="155.0" r="11.5" fill="white" stroke="#C87AA0" />
+      <text x="650.4" y="159.2" text-anchor="middle" class="logo">DG</text>
+      <text x="668.4" y="160.0" class="project-label">Dagger</text>
+    </g>
+  
+    <g class="project" data-name="Dify">
+      <rect x="774.4" y="140.0" width="148" height="34" rx="8" fill="#FCEFF7" stroke="#C87AA0" />
+      <circle cx="792.4" cy="157.0" r="11.5" fill="white" stroke="#C87AA0" />
+      <text x="792.4" y="161.2" text-anchor="middle" class="logo">DI</text>
+      <text x="810.4" y="162.0" class="project-label">Dify</text>
+    </g>
+  
+    <g class="project project-early" data-name="AIBrix">
+      <rect x="405.2" y="365.0" width="148" height="34" rx="8" fill="#EAF2FF" stroke="#5A88D8" />
+      <circle cx="423.2" cy="382.0" r="11.5" fill="white" stroke="#5A88D8" />
+      <text x="423.2" y="386.2" text-anchor="middle" class="logo">AB</text>
+      <text x="441.2" y="387.0" class="project-label">AIBrix</text>
+    </g>
+  
+    <g class="project project-early" data-name="Dynamo">
+      <rect x="504.6" y="401.0" width="148" height="34" rx="8" fill="#EAF2FF" stroke="#5A88D8" />
+      <circle cx="522.6" cy="418.0" r="11.5" fill="white" stroke="#5A88D8" />
+      <text x="522.6" y="422.2" text-anchor="middle" class="logo">DY</text>
+      <text x="540.6" y="423.0" class="project-label">Dynamo</text>
+    </g>
+  
+    <g class="project project-early" data-name="llmaz">
+      <rect x="334.2" y="419.0" width="148" height="34" rx="8" fill="#EAF2FF" stroke="#5A88D8" />
+      <circle cx="352.2" cy="436.0" r="11.5" fill="white" stroke="#5A88D8" />
+      <text x="352.2" y="440.2" text-anchor="middle" class="logo">LM</text>
+      <text x="370.2" y="441.0" class="project-label">llmaz</text>
+    </g>
+  
+    <g class="project" data-name="rbg">
+      <rect x="376.8" y="473.0" width="148" height="34" rx="8" fill="#EAF2FF" stroke="#5A88D8" />
+      <circle cx="394.8" cy="490.0" r="11.5" fill="white" stroke="#5A88D8" />
+      <text x="394.8" y="494.2" text-anchor="middle" class="logo">RB</text>
+      <text x="412.8" y="495.0" class="project-label">rbg</text>
+    </g>
+  
+    <g class="project" data-name="kthena">
+      <rect x="391.0" y="518.0" width="148" height="34" rx="8" fill="#EAF2FF" stroke="#5A88D8" />
+      <circle cx="409.0" cy="535.0" r="11.5" fill="white" stroke="#5A88D8" />
+      <text x="409.0" y="539.2" text-anchor="middle" class="logo">KT</text>
+      <text x="427.0" y="540.0" class="project-label">kthena</text>
+    </g>
+  
+    <g class="project project-early" data-name="kubeRay">
+      <rect x="547.2" y="491.0" width="148" height="34" rx="8" fill="#EAF2FF" stroke="#5A88D8" />
+      <circle cx="565.2" cy="508.0" r="11.5" fill="white" stroke="#5A88D8" />
+      <text x="565.2" y="512.2" text-anchor="middle" class="logo">KR</text>
+      <text x="583.2" y="513.0" class="project-label">kubeRay</text>
+    </g>
+  
+    <g class="project project-early" data-name="Semantic Router">
+      <rect x="650.3" y="275.0" width="169" height="34" rx="8" fill="#FDF1D2" stroke="#D5B062" />
+      <circle cx="668.3" cy="292.0" r="11.5" fill="white" stroke="#D5B062" />
+      <text x="668.3" y="296.2" text-anchor="middle" class="logo">SR</text>
+      <text x="686.3" y="297.0" class="project-label">Semantic Router</text>
+    </g>
+  
+    <g class="project project-early" data-name="Gateway API Inference Extension">
+      <rect x="704.9" y="230.0" width="287" height="34" rx="8" fill="#FDF1D2" stroke="#D5B062" />
+      <circle cx="722.9" cy="247.0" r="11.5" fill="white" stroke="#D5B062" />
+      <text x="722.9" y="251.2" text-anchor="middle" class="logo">GA</text>
+      <text x="740.9" y="252.0" class="project-label">Gateway API Inference Extension</text>
+    </g>
+  
+    <g class="project" data-name="Envoy AI Gateway">
+      <rect x="874.0" y="266.0" width="176" height="34" rx="8" fill="#FDF1D2" stroke="#D5B062" />
+      <circle cx="892.0" cy="283.0" r="11.5" fill="white" stroke="#D5B062" />
+      <text x="892.0" y="287.2" text-anchor="middle" class="logo">EA</text>
+      <text x="910.0" y="288.0" class="project-label">Envoy AI Gateway</text>
+    </g>
+  
+    <g class="project" data-name="kgateway">
+      <rect x="1001.6" y="293.0" width="148" height="34" rx="8" fill="#FDF1D2" stroke="#D5B062" />
+      <circle cx="1019.6" cy="310.0" r="11.5" fill="white" stroke="#D5B062" />
+      <text x="1019.6" y="314.2" text-anchor="middle" class="logo">KG</text>
+      <text x="1037.6" y="315.0" class="project-label">kgateway</text>
+    </g>
+  
+    <g class="project project-early" data-name="knoway">
+      <rect x="1072.6" y="293.0" width="148" height="34" rx="8" fill="#FDF1D2" stroke="#D5B062" />
+      <circle cx="1090.6" cy="310.0" r="11.5" fill="white" stroke="#D5B062" />
+      <text x="1090.6" y="314.2" text-anchor="middle" class="logo">KW</text>
+      <text x="1108.6" y="315.0" class="project-label">knoway</text>
+    </g>
+  
+    <g class="project" data-name="Higress">
+      <rect x="916.4" y="311.0" width="148" height="34" rx="8" fill="#FDF1D2" stroke="#D5B062" />
+      <circle cx="934.4" cy="328.0" r="11.5" fill="white" stroke="#D5B062" />
+      <text x="934.4" y="332.2" text-anchor="middle" class="logo">HG</text>
+      <text x="952.4" y="333.0" class="project-label">Higress</text>
+    </g>
+  
+    <g class="project" data-name="Kong">
+      <rect x="973.2" y="329.0" width="148" height="34" rx="8" fill="#FDF1D2" stroke="#D5B062" />
+      <circle cx="991.2" cy="346.0" r="11.5" fill="white" stroke="#D5B062" />
+      <text x="991.2" y="350.2" text-anchor="middle" class="logo">KO</text>
+      <text x="1009.2" y="351.0" class="project-label">Kong</text>
+    </g>
+  
+    <g class="project" data-name="Istio">
+      <rect x="1030.0" y="203.0" width="148" height="34" rx="8" fill="#FDF1D2" stroke="#D5B062" />
+      <circle cx="1048.0" cy="220.0" r="11.5" fill="white" stroke="#D5B062" />
+      <text x="1048.0" y="224.2" text-anchor="middle" class="logo">IS</text>
+      <text x="1066.0" y="225.0" class="project-label">Istio</text>
+    </g>
+  
+    <g class="project" data-name="KServe">
+      <rect x="1086.8" y="365.0" width="148" height="34" rx="8" fill="#EAF2FF" stroke="#5A88D8" />
+      <circle cx="1104.8" cy="382.0" r="11.5" fill="white" stroke="#5A88D8" />
+      <text x="1104.8" y="386.2" text-anchor="middle" class="logo">KS</text>
+      <text x="1122.8" y="387.0" class="project-label">KServe</text>
+    </g>
+  
+    <g class="project" data-name="Knative">
+      <rect x="1172.0" y="374.0" width="148" height="34" rx="8" fill="#FCEFF7" stroke="#C87AA0" />
+      <circle cx="1190.0" cy="391.0" r="11.5" fill="white" stroke="#C87AA0" />
+      <text x="1190.0" y="395.2" text-anchor="middle" class="logo">KN</text>
+      <text x="1208.0" y="396.0" class="project-label">Knative</text>
+    </g>
+  
+    <g class="project" data-name="Kubeflow">
+      <rect x="1314.0" y="338.0" width="148" height="34" rx="8" fill="#FFF3E8" stroke="#D59B5A" />
+      <circle cx="1332.0" cy="355.0" r="11.5" fill="white" stroke="#D59B5A" />
+      <text x="1332.0" y="359.2" text-anchor="middle" class="logo">KF</text>
+      <text x="1350.0" y="360.0" class="project-label">Kubeflow</text>
+    </g>
+  
+    <g class="project" data-name="Kubeflow Trainer">
+      <rect x="1328.4" y="383.0" width="176" height="34" rx="8" fill="#FFF3E8" stroke="#D59B5A" />
+      <circle cx="1346.4" cy="400.0" r="11.5" fill="white" stroke="#D59B5A" />
+      <text x="1346.4" y="404.2" text-anchor="middle" class="logo">KT</text>
+      <text x="1364.4" y="405.0" class="project-label">Kubeflow Trainer</text>
+    </g>
+  
+    <g class="project" data-name="SGLang">
+      <rect x="675.0" y="518.0" width="148" height="34" rx="8" fill="#EAF2FF" stroke="#5A88D8" />
+      <circle cx="693.0" cy="535.0" r="11.5" fill="white" stroke="#5A88D8" />
+      <text x="693.0" y="539.2" text-anchor="middle" class="logo">SG</text>
+      <text x="711.0" y="540.0" class="project-label">SGLang</text>
+    </g>
+  
+    <g class="project" data-name="vLLM">
+      <rect x="802.8" y="572.0" width="148" height="34" rx="8" fill="#EAF2FF" stroke="#5A88D8" />
+      <circle cx="820.8" cy="589.0" r="11.5" fill="white" stroke="#5A88D8" />
+      <text x="820.8" y="593.2" text-anchor="middle" class="logo">VL</text>
+      <text x="838.8" y="594.0" class="project-label">vLLM</text>
+    </g>
+  
+    <g class="project" data-name="Triton Inference Server">
+      <rect x="791.2" y="635.0" width="228" height="34" rx="8" fill="#EAF2FF" stroke="#5A88D8" />
+      <circle cx="809.2" cy="652.0" r="11.5" fill="white" stroke="#5A88D8" />
+      <text x="809.2" y="656.2" text-anchor="middle" class="logo">TR</text>
+      <text x="827.2" y="657.0" class="project-label">Triton Inference Server</text>
+    </g>
+  
+    <g class="project project-early" data-name="LWS">
+      <rect x="518.8" y="563.0" width="148" height="34" rx="8" fill="#EBF8EE" stroke="#65A97B" />
+      <circle cx="536.8" cy="580.0" r="11.5" fill="white" stroke="#65A97B" />
+      <text x="536.8" y="584.2" text-anchor="middle" class="logo">LW</text>
+      <text x="554.8" y="585.0" class="project-label">LWS</text>
+    </g>
+  
+    <g class="project project-early" data-name="JobSet">
+      <rect x="774.4" y="509.0" width="148" height="34" rx="8" fill="#EBF8EE" stroke="#65A97B" />
+      <circle cx="792.4" cy="526.0" r="11.5" fill="white" stroke="#65A97B" />
+      <text x="792.4" y="530.2" text-anchor="middle" class="logo">JS</text>
+      <text x="810.4" y="531.0" class="project-label">JobSet</text>
+    </g>
+  
+    <g class="project" data-name="Godel">
+      <rect x="348.4" y="653.0" width="148" height="34" rx="8" fill="#EBF8EE" stroke="#65A97B" />
+      <circle cx="366.4" cy="670.0" r="11.5" fill="white" stroke="#65A97B" />
+      <text x="366.4" y="674.2" text-anchor="middle" class="logo">GD</text>
+      <text x="384.4" y="675.0" class="project-label">Godel</text>
+    </g>
+  
+    <g class="project project-early" data-name="Kai Scheduler">
+      <rect x="444.8" y="671.0" width="154" height="34" rx="8" fill="#EBF8EE" stroke="#65A97B" />
+      <circle cx="462.8" cy="688.0" r="11.5" fill="white" stroke="#65A97B" />
+      <text x="462.8" y="692.2" text-anchor="middle" class="logo">KI</text>
+      <text x="480.8" y="693.0" class="project-label">Kai Scheduler</text>
+    </g>
+  
+    <g class="project" data-name="Volcano">
+      <rect x="589.8" y="689.0" width="148" height="34" rx="8" fill="#EBF8EE" stroke="#65A97B" />
+      <circle cx="607.8" cy="706.0" r="11.5" fill="white" stroke="#65A97B" />
+      <text x="607.8" y="710.2" text-anchor="middle" class="logo">VO</text>
+      <text x="625.8" y="711.0" class="project-label">Volcano</text>
+    </g>
+  
+    <g class="project" data-name="Kueue">
+      <rect x="973.2" y="635.0" width="148" height="34" rx="8" fill="#EBF8EE" stroke="#65A97B" />
+      <circle cx="991.2" cy="652.0" r="11.5" fill="white" stroke="#65A97B" />
+      <text x="991.2" y="656.2" text-anchor="middle" class="logo">KQ</text>
+      <text x="1009.2" y="657.0" class="project-label">Kueue</text>
+    </g>
+  
+    <g class="project" data-name="YuniKorn">
+      <rect x="1157.8" y="626.0" width="148" height="34" rx="8" fill="#EBF8EE" stroke="#65A97B" />
+      <circle cx="1175.8" cy="643.0" r="11.5" fill="white" stroke="#65A97B" />
+      <text x="1175.8" y="647.2" text-anchor="middle" class="logo">YK</text>
+      <text x="1193.8" y="648.0" class="project-label">YuniKorn</text>
+    </g>
+  
+    <g class="project" data-name="Koordinator">
+      <rect x="1101.0" y="689.0" width="148" height="34" rx="8" fill="#EBF8EE" stroke="#65A97B" />
+      <circle cx="1119.0" cy="706.0" r="11.5" fill="white" stroke="#65A97B" />
+      <text x="1119.0" y="710.2" text-anchor="middle" class="logo">KD</text>
+      <text x="1137.0" y="711.0" class="project-label">Koordinator</text>
+    </g>
+  
+    <g class="project project-early" data-name="PodRestart">
+      <rect x="632.4" y="761.0" width="148" height="34" rx="8" fill="#EEF2FF" stroke="#667EEA" />
+      <circle cx="650.4" cy="778.0" r="11.5" fill="white" stroke="#667EEA" />
+      <text x="650.4" y="782.2" text-anchor="middle" class="logo">PR</text>
+      <text x="668.4" y="783.0" class="project-label">PodRestart</text>
+    </g>
+  
+    <g class="project project-early" data-name="ImageVolume">
+      <rect x="675.0" y="806.0" width="148" height="34" rx="8" fill="#EEF2FF" stroke="#667EEA" />
+      <circle cx="693.0" cy="823.0" r="11.5" fill="white" stroke="#667EEA" />
+      <text x="693.0" y="827.2" text-anchor="middle" class="logo">IV</text>
+      <text x="711.0" y="828.0" class="project-label">ImageVolume</text>
+    </g>
+  
+    <g class="project project-early" data-name="DRA">
+      <rect x="774.4" y="770.0" width="148" height="34" rx="8" fill="#EEF2FF" stroke="#667EEA" />
+      <circle cx="792.4" cy="787.0" r="11.5" fill="white" stroke="#667EEA" />
+      <text x="792.4" y="791.2" text-anchor="middle" class="logo">DR</text>
+      <text x="810.4" y="792.0" class="project-label">DRA</text>
+    </g>
+  
+    <g class="project project-early" data-name="NRI">
+      <rect x="462.0" y="851.0" width="148" height="34" rx="8" fill="#EEF2FF" stroke="#667EEA" />
+      <circle cx="480.0" cy="868.0" r="11.5" fill="white" stroke="#667EEA" />
+      <text x="480.0" y="872.2" text-anchor="middle" class="logo">NR</text>
+      <text x="498.0" y="873.0" class="project-label">NRI</text>
+    </g>
+  
+    <g class="project project-early" data-name="Model Spec">
+      <rect x="178.0" y="833.0" width="148" height="34" rx="8" fill="#EEF2FF" stroke="#667EEA" />
+      <circle cx="196.0" cy="850.0" r="11.5" fill="white" stroke="#667EEA" />
+      <text x="196.0" y="854.2" text-anchor="middle" class="logo">MS</text>
+      <text x="214.0" y="855.0" class="project-label">Model Spec</text>
+    </g>
+  
+    <g class="project" data-name="KWOK">
+      <rect x="1030.0" y="833.0" width="148" height="34" rx="8" fill="#EEF2FF" stroke="#667EEA" />
+      <circle cx="1048.0" cy="850.0" r="11.5" fill="white" stroke="#667EEA" />
+      <text x="1048.0" y="854.2" text-anchor="middle" class="logo">KW</text>
+      <text x="1066.0" y="855.0" class="project-label">KWOK</text>
+    </g>
+  
+    <g class="project" data-name="Kubernetes">
+      <rect x="1314.0" y="851.0" width="148" height="34" rx="8" fill="#EEF2FF" stroke="#667EEA" />
+      <circle cx="1332.0" cy="868.0" r="11.5" fill="white" stroke="#667EEA" />
+      <text x="1332.0" y="872.2" text-anchor="middle" class="logo">K8</text>
+      <text x="1350.0" y="873.0" class="project-label">Kubernetes</text>
+    </g>
+  
+    <g class="project" data-name="containerd">
+      <rect x="1285.6" y="923.0" width="148" height="34" rx="8" fill="#EEF2FF" stroke="#667EEA" />
+      <circle cx="1303.6" cy="940.0" r="11.5" fill="white" stroke="#667EEA" />
+      <text x="1303.6" y="944.2" text-anchor="middle" class="logo">CD</text>
+      <text x="1321.6" y="945.0" class="project-label">containerd</text>
+    </g>
+  
+    <g class="project" data-name="KubeVirt">
+      <rect x="1143.6" y="905.0" width="148" height="34" rx="8" fill="#EEF2FF" stroke="#667EEA" />
+      <circle cx="1161.6" cy="922.0" r="11.5" fill="white" stroke="#667EEA" />
+      <text x="1161.6" y="926.2" text-anchor="middle" class="logo">KV</text>
+      <text x="1179.6" y="927.0" class="project-label">KubeVirt</text>
+    </g>
+
+  
+    <g class="note" transform="translate(1560, 198)">
+      <rect x="0" y="0" width="220" height="44" rx="2" fill="#FDF1D2" stroke="#D5B062" />
+      <text class="note-label"><tspan x="14" y="28">AI Gateway</tspan></text>
+    </g>
+  
+    <g class="note" transform="translate(1560, 288)">
+      <rect x="0" y="0" width="220" height="44" rx="2" fill="#FCEFF7" stroke="#C87AA0" />
+      <text class="note-label"><tspan x="14" y="28">Workflow</tspan></text>
+    </g>
+  
+    <g class="note" transform="translate(1560, 342)">
+      <rect x="0" y="0" width="220" height="44" rx="2" fill="#FFF3E8" stroke="#D59B5A" />
+      <text class="note-label"><tspan x="14" y="28">Training</tspan></text>
+    </g>
+  
+    <g class="note" transform="translate(1560, 396)">
+      <rect x="0" y="0" width="220" height="44" rx="2" fill="#FCEFF7" stroke="#C87AA0" />
+      <text class="note-label"><tspan x="14" y="28">Serverless</tspan></text>
+    </g>
+  
+    <g class="note" transform="translate(1560, 422)">
+      <rect x="0" y="0" width="220" height="46" rx="2" fill="#EAF2FF" stroke="#5A88D8" />
+      <text class="note-label"><tspan x="14" y="20">Cloud-native</tspan><tspan x="14" y="36">Inference</tspan></text>
+    </g>
+  
+    <g class="note" transform="translate(1560, 504)">
+      <rect x="0" y="0" width="220" height="44" rx="2" fill="#EAF2FF" stroke="#5A88D8" />
+      <text class="note-label"><tspan x="14" y="28">Inference</tspan></text>
+    </g>
+  
+    <g class="note" transform="translate(1560, 594)">
+      <rect x="0" y="0" width="220" height="44" rx="2" fill="#EBF8EE" stroke="#65A97B" />
+      <text class="note-label"><tspan x="14" y="28">Scheduling</tspan></text>
+    </g>
+  
+    <g class="note" transform="translate(1560, 828)">
+      <rect x="0" y="0" width="220" height="44" rx="2" fill="#EEF2FF" stroke="#667EEA" />
+      <text class="note-label"><tspan x="14" y="28">Orchestration</tspan></text>
+    </g>
+  
+    <g class="note" transform="translate(1560, 918)">
+      <rect x="0" y="0" width="220" height="44" rx="2" fill="#EEF2FF" stroke="#667EEA" />
+      <text class="note-label"><tspan x="14" y="28">Kernel</tspan></text>
+    </g>
+
+  <text x="110" y="1068" class="footer">Scope note: this landscape intentionally excludes storage, networking, and VM-specific projects.</text>
+  <text x="110" y="1088" class="footer">Maintenance: edit diagrams/ai-infra-landscape.data.json then run node scripts/generate-landscape-svg.js</text>
+</svg>

--- a/scripts/generate-landscape-svg.js
+++ b/scripts/generate-landscape-svg.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const dataPath = path.join(repoRoot, 'diagrams', 'ai-infra-landscape.data.json');
+const outPath = path.join(repoRoot, 'diagrams', 'ai-infra-landscape.svg');
+
+const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+
+const canvas = { width: 1800, height: 1150 };
+const chart = { x: 110, y: 130, width: 1420, height: 900 };
+const notesX = chart.x + chart.width + 30;
+const notesWidth = 220;
+
+function escapeXml(input) {
+  return String(input)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function toX(value) {
+  return chart.x + (value / 100) * chart.width;
+}
+
+function toY(value) {
+  return chart.y + ((100 - value) / 100) * chart.height;
+}
+
+function textWidth(name) {
+  return Math.max(88, Math.round([...name].length * 7.4));
+}
+
+function cardDimensions(name) {
+  return {
+    width: Math.max(148, 58 + textWidth(name)),
+    height: 34
+  };
+}
+
+function clamp(num, min, max) {
+  return Math.min(max, Math.max(min, num));
+}
+
+function logoText(name, manual) {
+  if (manual) return manual;
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0].toUpperCase())
+    .join('');
+}
+
+function wrapWords(text, maxChars) {
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines = [];
+  let current = '';
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length <= maxChars || current.length === 0) {
+      current = next;
+      continue;
+    }
+    lines.push(current);
+    current = word;
+  }
+  if (current) lines.push(current);
+  return lines.length ? lines : [text];
+}
+
+function projectNode(project) {
+  const group = data.groups[project.group] || data.groups.kernel;
+  const baseX = toX(project.x);
+  const baseY = toY(project.y);
+  const size = cardDimensions(project.name);
+
+  const left = clamp(baseX - size.width / 2, chart.x + 8, chart.x + chart.width - size.width - 8);
+  const top = clamp(baseY - size.height / 2, chart.y + 8, chart.y + chart.height - size.height - 8);
+  const dashed = project.stage === 'early' ? ' project-early' : '';
+  const bubble = logoText(project.name, project.logo);
+
+  return `
+    <g class="project${dashed}" data-name="${escapeXml(project.name)}">
+      <rect x="${left.toFixed(1)}" y="${top.toFixed(1)}" width="${size.width}" height="${size.height}" rx="8" fill="${group.fill}" stroke="${group.stroke}" />
+      <circle cx="${(left + 18).toFixed(1)}" cy="${(top + size.height / 2).toFixed(1)}" r="11.5" fill="white" stroke="${group.stroke}" />
+      <text x="${(left + 18).toFixed(1)}" y="${(top + size.height / 2 + 4.2).toFixed(1)}" text-anchor="middle" class="logo">${escapeXml(bubble)}</text>
+      <text x="${(left + 36).toFixed(1)}" y="${(top + size.height / 2 + 5).toFixed(1)}" class="project-label">${escapeXml(project.name)}</text>
+    </g>`;
+}
+
+function noteNode(note) {
+  const group = data.groups[note.group] || data.groups.kernel;
+  const y = toY(note.y);
+  const lines = wrapWords(note.label, 20);
+  const lineHeight = 16;
+  const textStart = lines.length > 1 ? 20 : 28;
+  const height = Math.max(44, 14 + lines.length * lineHeight);
+  const lineMarkup = lines
+    .map((line, index) => `<tspan x="14" y="${textStart + index * lineHeight}">${escapeXml(line)}</tspan>`)
+    .join('');
+  return `
+    <g class="note" transform="translate(${notesX}, ${y - height / 2})">
+      <rect x="0" y="0" width="${notesWidth}" height="${height}" rx="2" fill="${group.fill}" stroke="${group.stroke}" />
+      <text class="note-label">${lineMarkup}</text>
+    </g>`;
+}
+
+function ecosystemNode(item) {
+  const group = data.groups[item.group] || data.groups.training;
+  const x = toX(item.x);
+  const y = 58;
+  const width = Math.max(96, textWidth(item.name) + 34);
+  return `
+    <g class="ecosystem-item" transform="translate(${(x - width / 2).toFixed(1)}, ${y})">
+      <rect x="0" y="0" width="${width}" height="34" rx="17" fill="${group.fill}" stroke="${group.stroke}" />
+      <circle cx="18" cy="17" r="8" fill="white" stroke="${group.stroke}" />
+      <text x="18" y="21" text-anchor="middle" class="ecosystem-logo">${escapeXml(logoText(item.name))}</text>
+      <text x="32" y="22" class="ecosystem-label">${escapeXml(item.name)}</text>
+    </g>`;
+}
+
+const quadrantBackgrounds = [
+  { x: chart.x, y: chart.y, width: chart.width / 2, height: chart.height / 2, fill: '#FBFCFF' },
+  { x: chart.x + chart.width / 2, y: chart.y, width: chart.width / 2, height: chart.height / 2, fill: '#FAFDFF' },
+  { x: chart.x, y: chart.y + chart.height / 2, width: chart.width / 2, height: chart.height / 2, fill: '#FCFCFD' },
+  { x: chart.x + chart.width / 2, y: chart.y + chart.height / 2, width: chart.width / 2, height: chart.height / 2, fill: '#FBFCFE' }
+];
+
+const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${canvas.width}" height="${canvas.height}" viewBox="0 0 ${canvas.width} ${canvas.height}" role="img" aria-labelledby="title desc">
+  <title id="title">${escapeXml(data.meta.title)} (${escapeXml(data.meta.version)})</title>
+  <desc id="desc">Four-quadrant AI infra landscape generated from data for easy maintenance.</desc>
+  <defs>
+    <style>
+      .title { font: 700 42px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .subtitle { font: 500 19px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #4b5563; }
+      .axis-label { font: 600 26px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #374151; }
+      .quad-label { font: 600 16px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #6b7280; }
+      .legend { font: 500 15px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #374151; }
+      .project-label { font: 600 14px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .logo { font: 700 10px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #374151; }
+      .ecosystem-label { font: 600 13px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .ecosystem-logo { font: 700 8px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #374151; }
+      .note-label { font: 600 15px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #1f2937; }
+      .project-early rect,
+      .project-early circle { stroke-dasharray: 4 4; }
+      .footer { font: 500 13px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #6b7280; }
+    </style>
+  </defs>
+
+  <rect x="0" y="0" width="${canvas.width}" height="${canvas.height}" fill="#f4f5f7" />
+
+  <text x="${chart.x}" y="52" class="title">${escapeXml(data.meta.title)}</text>
+  <text x="${chart.x}" y="82" class="subtitle">${escapeXml(data.meta.version)} | Last updated ${escapeXml(data.meta.last_updated)}</text>
+
+  ${quadrantBackgrounds
+    .map((q) => `<rect x="${q.x}" y="${q.y}" width="${q.width}" height="${q.height}" fill="${q.fill}" />`)
+    .join('\n  ')}
+
+  <rect x="${chart.x}" y="${chart.y}" width="${chart.width}" height="${chart.height}" fill="none" stroke="#1f2937" stroke-width="2" stroke-dasharray="6 5" />
+  <line x1="${chart.x + chart.width / 2}" y1="${chart.y}" x2="${chart.x + chart.width / 2}" y2="${chart.y + chart.height}" stroke="#4b5563" stroke-width="2" stroke-dasharray="6 5" />
+  <line x1="${chart.x}" y1="${chart.y + chart.height / 2}" x2="${chart.x + chart.width}" y2="${chart.y + chart.height / 2}" stroke="#4b5563" stroke-width="2" stroke-dasharray="6 5" />
+
+  <text x="${chart.x + chart.width / 2}" y="${chart.y - 24}" text-anchor="middle" class="axis-label">${escapeXml(data.axes.y_top)}</text>
+  <text x="${chart.x + chart.width / 2}" y="${chart.y + chart.height + 78}" text-anchor="middle" class="axis-label">${escapeXml(data.axes.y_bottom)}</text>
+  <text x="${chart.x - 18}" y="${chart.y + chart.height / 2}" text-anchor="end" class="axis-label">${escapeXml(data.axes.x_left)}</text>
+  <text x="${chart.x + chart.width + 18}" y="${chart.y + chart.height / 2}" class="axis-label">${escapeXml(data.axes.x_right)}</text>
+
+  ${data.quadrants
+    .map(
+      (q) =>
+        `<text x="${toX(q.x)}" y="${toY(q.y)}" class="quad-label">${escapeXml(q.label)}</text>`
+    )
+    .join('\n  ')}
+
+  <text x="${chart.x}" y="104" class="legend">Legend: dashed border = early stage / under exploration</text>
+
+  ${data.ecosystem.map((item) => ecosystemNode(item)).join('\n  ')}
+
+  ${data.projects.map((project) => projectNode(project)).join('\n  ')}
+
+  ${data.right_notes.map((note) => noteNode(note)).join('\n  ')}
+
+  <text x="${chart.x}" y="${chart.y + chart.height + 38}" class="footer">Scope note: this landscape intentionally excludes storage, networking, and VM-specific projects.</text>
+  <text x="${chart.x}" y="${chart.y + chart.height + 58}" class="footer">Maintenance: edit diagrams/ai-infra-landscape.data.json then run node scripts/generate-landscape-svg.js</text>
+</svg>
+`;
+
+fs.writeFileSync(outPath, svg);
+console.log(`Generated ${path.relative(repoRoot, outPath)} from ${path.relative(repoRoot, dataPath)}`);


### PR DESCRIPTION
## Summary
- redraw AI-Infra landscape into a four-quadrant, maintainable SVG
- add data source file for projects/positions/grouping (`diagrams/ai-infra-landscape.data.json`)
- add generator script (`scripts/generate-landscape-svg.js`) and regenerate output SVG
- update README and STRUCTURE docs to reference SVG and maintenance workflow

## How to update
```bash
node ./scripts/generate-landscape-svg.js
```

## Notes
- dashed project cards represent early-stage/exploratory items
- current logo rendering uses monogram badges for maintainability
