### PR TITLE
Add GitHub-maintained MCM radar (CNCF + ecosystem)

### DIFF
--- a/diagrams/mcm-multicluster-radar.data.json
+++ b/diagrams/mcm-multicluster-radar.data.json
@@ -1,0 +1,275 @@
+{
+  "meta": {
+    "title": "Multi-Cluster Management Radar",
+    "version": "2026-Q1",
+    "last_updated": "2026-03-23",
+    "note": "Edit this file and run node scripts/generate-mcm-radar-svg.js to regenerate diagrams/mcm-multicluster-radar.svg"
+  },
+  "rings": [
+    {
+      "id": "adopt",
+      "label": "ADOPT",
+      "description": "Production default choices for most teams",
+      "fill": "#E8F6EC",
+      "stroke": "#53A66A"
+    },
+    {
+      "id": "trial",
+      "label": "TRIAL",
+      "description": "Strong candidates to evaluate in production pilots",
+      "fill": "#EAF2FF",
+      "stroke": "#4E7FD1"
+    },
+    {
+      "id": "assess",
+      "label": "ASSESS",
+      "description": "Promising options that need focused validation",
+      "fill": "#FFF5E8",
+      "stroke": "#D58A39"
+    },
+    {
+      "id": "hold",
+      "label": "HOLD",
+      "description": "Legacy patterns to avoid for new designs",
+      "fill": "#FDECEC",
+      "stroke": "#CC5F5F"
+    }
+  ],
+  "sectors": [
+    {
+      "id": "control",
+      "label": "Control Plane & Orchestration",
+      "start": -90,
+      "end": -30
+    },
+    {
+      "id": "delivery",
+      "label": "GitOps & App Delivery",
+      "start": -30,
+      "end": 30
+    },
+    {
+      "id": "lifecycle",
+      "label": "Cluster Lifecycle & IaC",
+      "start": 30,
+      "end": 90
+    },
+    {
+      "id": "tenancy",
+      "label": "Tenancy & API Virtualization",
+      "start": 90,
+      "end": 150
+    },
+    {
+      "id": "ui",
+      "label": "Portal & Visibility",
+      "start": 150,
+      "end": 210
+    },
+    {
+      "id": "testing",
+      "label": "Scale Testing & Scheduling",
+      "start": 210,
+      "end": 270
+    }
+  ],
+  "sources": {
+    "cncf": {
+      "label": "CNCF",
+      "fill": "#E8F1FF",
+      "stroke": "#3B82F6"
+    },
+    "ecosystem": {
+      "label": "Ecosystem (Non-CNCF)",
+      "fill": "#FFF4E8",
+      "stroke": "#D97706"
+    },
+    "kubewharf": {
+      "label": "Kubewharf Ecosystem",
+      "fill": "#F3E8FF",
+      "stroke": "#9333EA"
+    }
+  },
+  "projects": [
+    {
+      "name": "Argo CD",
+      "ring": "adopt",
+      "sector": "delivery",
+      "source": "cncf"
+    },
+    {
+      "name": "Flux CD",
+      "ring": "adopt",
+      "sector": "delivery",
+      "source": "cncf"
+    },
+    {
+      "name": "Cluster API",
+      "ring": "adopt",
+      "sector": "lifecycle",
+      "source": "cncf"
+    },
+    {
+      "name": "Terraform",
+      "ring": "adopt",
+      "sector": "lifecycle",
+      "source": "ecosystem"
+    },
+    {
+      "name": "Cilium Cluster Mesh",
+      "ring": "adopt",
+      "sector": "control",
+      "source": "cncf"
+    },
+    {
+      "name": "Lens",
+      "ring": "adopt",
+      "sector": "ui",
+      "source": "ecosystem"
+    },
+    {
+      "name": "Kubernetes Dashboard",
+      "ring": "adopt",
+      "sector": "ui",
+      "source": "ecosystem"
+    },
+    {
+      "name": "KubeSphere Console",
+      "ring": "adopt",
+      "sector": "ui",
+      "source": "ecosystem"
+    },
+    {
+      "name": "Karmada",
+      "ring": "trial",
+      "sector": "control",
+      "source": "cncf"
+    },
+    {
+      "name": "Open Cluster Management",
+      "ring": "trial",
+      "sector": "control",
+      "source": "cncf"
+    },
+    {
+      "name": "KubeStellar",
+      "ring": "trial",
+      "sector": "control",
+      "source": "cncf"
+    },
+    {
+      "name": "Clusternet",
+      "ring": "trial",
+      "sector": "control",
+      "source": "ecosystem"
+    },
+    {
+      "name": "Fleet",
+      "ring": "trial",
+      "sector": "delivery",
+      "source": "ecosystem"
+    },
+    {
+      "name": "Virtual Kubelet",
+      "ring": "trial",
+      "sector": "tenancy",
+      "source": "ecosystem"
+    },
+    {
+      "name": "vCluster",
+      "ring": "trial",
+      "sector": "tenancy",
+      "source": "ecosystem"
+    },
+    {
+      "name": "Headlamp",
+      "ring": "trial",
+      "sector": "ui",
+      "source": "cncf"
+    },
+    {
+      "name": "KWOK",
+      "ring": "trial",
+      "sector": "testing",
+      "source": "ecosystem"
+    },
+    {
+      "name": "Volcano",
+      "ring": "trial",
+      "sector": "testing",
+      "source": "cncf"
+    },
+    {
+      "name": "KubeAdmiral",
+      "ring": "assess",
+      "sector": "control",
+      "source": "kubewharf"
+    },
+    {
+      "name": "kubeBrain",
+      "ring": "assess",
+      "sector": "control",
+      "source": "kubewharf"
+    },
+    {
+      "name": "KubeZoo",
+      "ring": "assess",
+      "sector": "tenancy",
+      "source": "kubewharf"
+    },
+    {
+      "name": "KCP",
+      "ring": "assess",
+      "sector": "tenancy",
+      "source": "ecosystem"
+    },
+    {
+      "name": "Kamaji",
+      "ring": "assess",
+      "sector": "tenancy",
+      "source": "ecosystem"
+    },
+    {
+      "name": "PipeCD",
+      "ring": "assess",
+      "sector": "delivery",
+      "source": "ecosystem"
+    },
+    {
+      "name": "Godel Scheduler",
+      "ring": "assess",
+      "sector": "testing",
+      "source": "kubewharf"
+    },
+    {
+      "name": "Katalyst",
+      "ring": "assess",
+      "sector": "testing",
+      "source": "kubewharf"
+    },
+    {
+      "name": "Koordinator",
+      "ring": "assess",
+      "sector": "testing",
+      "source": "cncf"
+    },
+    {
+      "name": "KubeFed v1",
+      "ring": "hold",
+      "sector": "control",
+      "source": "ecosystem"
+    },
+    {
+      "name": "Custom kubeconfig fan-out scripts",
+      "ring": "hold",
+      "sector": "delivery",
+      "source": "ecosystem"
+    },
+    {
+      "name": "Untested multi-cluster operators",
+      "ring": "hold",
+      "sector": "testing",
+      "source": "ecosystem"
+    }
+  ]
+}

--- a/diagrams/mcm-multicluster-radar.svg
+++ b/diagrams/mcm-multicluster-radar.svg
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1880" height="1260" viewBox="0 0 1880 1260" role="img" aria-labelledby="title desc">
+  <title id="title">Multi-Cluster Management Radar (2026-Q1)</title>
+  <desc id="desc">Multi-cluster management technology radar generated from JSON data for easy GitHub maintenance.</desc>
+  <defs>
+    <style>
+      .title { font: 700 42px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .subtitle { font: 500 19px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #4B5563; }
+      .sector-label { font: 600 13px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #334155; }
+      .ring-label { font: 700 14px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #475569; letter-spacing: 0.6px; }
+      .dot-id { font: 700 10.5px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .legend-title { font: 700 24px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .legend-note { font: 500 13.5px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #4B5563; }
+      .legend-source { font: 600 13px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #334155; }
+      .legend-ring-title { font: 700 16px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; }
+      .legend-ring-desc { font: 500 12.5px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #64748B; }
+      .legend-item { font: 500 12.5px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #1F2937; }
+      .footer { font: 500 13px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #64748B; }
+    </style>
+  </defs>
+
+  <rect x="0" y="0" width="1880" height="1260" fill="#F3F5F8" />
+  <rect x="1080" y="128" width="730" height="1010" rx="16" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1.4" />
+
+  <text x="76" y="72" class="title">Multi-Cluster Management Radar</text>
+  <text x="76" y="102" class="subtitle">2026-Q1 | updated 2026-03-23</text>
+
+  <path d="M 560.00 140.00 A 500 500 0 0 1 993.01 390.00 L 634.48 597.00 A 86 86 0 0 0 560.00 554.00 Z" fill="#FAFCFF" />
+  <path d="M 993.01 390.00 A 500 500 0 0 1 993.01 890.00 L 634.48 683.00 A 86 86 0 0 0 634.48 597.00 Z" fill="#F7FAFC" />
+  <path d="M 993.01 890.00 A 500 500 0 0 1 560.00 1140.00 L 560.00 726.00 A 86 86 0 0 0 634.48 683.00 Z" fill="#FAFCFF" />
+  <path d="M 560.00 1140.00 A 500 500 0 0 1 126.99 890.00 L 485.52 683.00 A 86 86 0 0 0 560.00 726.00 Z" fill="#F7FAFC" />
+  <path d="M 126.99 890.00 A 500 500 0 0 1 126.99 390.00 L 485.52 597.00 A 86 86 0 0 0 485.52 683.00 Z" fill="#FAFCFF" />
+  <path d="M 126.99 390.00 A 500 500 0 0 1 560.00 140.00 L 560.00 554.00 A 86 86 0 0 0 485.52 597.00 Z" fill="#F7FAFC" />
+  <circle cx="560" cy="640" r="500.00" fill="#FDECEC" fill-opacity="0.36" stroke="#CC5F5F" stroke-width="1.4" />
+  <circle cx="560" cy="640" r="396.50" fill="#FFF5E8" fill-opacity="0.36" stroke="#D58A39" stroke-width="1.4" />
+  <circle cx="560" cy="640" r="293.00" fill="#EAF2FF" fill-opacity="0.36" stroke="#4E7FD1" stroke-width="1.4" />
+  <circle cx="560" cy="640" r="189.50" fill="#E8F6EC" fill-opacity="0.36" stroke="#53A66A" stroke-width="1.4" />
+  <circle cx="560" cy="640" r="189.50" fill="none" stroke="#8A94A6" stroke-width="0.8" stroke-dasharray="4 5" />
+  <circle cx="560" cy="640" r="293.00" fill="none" stroke="#8A94A6" stroke-width="0.8" stroke-dasharray="4 5" />
+  <circle cx="560" cy="640" r="396.50" fill="none" stroke="#8A94A6" stroke-width="0.8" stroke-dasharray="4 5" />
+  <circle cx="560" cy="640" r="500.00" fill="none" stroke="#8A94A6" stroke-width="0.8" stroke-dasharray="4 5" />
+  <line x1="560.00" y1="554.00" x2="560.00" y2="140.00" stroke="#99A3B2" stroke-width="1.1" />
+  <line x1="634.48" y1="597.00" x2="993.01" y2="390.00" stroke="#99A3B2" stroke-width="1.1" />
+  <line x1="634.48" y1="683.00" x2="993.01" y2="890.00" stroke="#99A3B2" stroke-width="1.1" />
+  <line x1="560.00" y1="726.00" x2="560.00" y2="1140.00" stroke="#99A3B2" stroke-width="1.1" />
+  <line x1="485.52" y1="683.00" x2="126.99" y2="890.00" stroke="#99A3B2" stroke-width="1.1" />
+  <line x1="485.52" y1="597.00" x2="126.99" y2="390.00" stroke="#99A3B2" stroke-width="1.1" />
+  <text x="827.00" y="181.54" text-anchor="start" class="sector-label">Control Plane &amp; Orchestration</text>
+  <text x="1094.00" y="644.00" text-anchor="start" class="sector-label">GitOps &amp; App Delivery</text>
+  <text x="827.00" y="1106.46" text-anchor="start" class="sector-label">Cluster Lifecycle &amp; IaC</text>
+  <text x="293.00" y="1106.46" text-anchor="end" class="sector-label">Tenancy &amp; API Virtualization</text>
+  <text x="26.00" y="644.00" text-anchor="end" class="sector-label">Portal &amp; Visibility</text>
+  <text x="293.00" y="181.54" text-anchor="end" class="sector-label">Scale Testing &amp; Scheduling</text>
+  <text x="514.68" y="510.34" text-anchor="end" class="ring-label">ADOPT</text>
+  <text x="489.64" y="409.92" text-anchor="end" class="ring-label">TRIAL</text>
+  <text x="464.60" y="309.49" text-anchor="end" class="ring-label">ASSESS</text>
+  <text x="439.56" y="209.06" text-anchor="end" class="ring-label">HOLD</text>
+
+  <circle cx="560" cy="640" r="84" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1.2" />
+  <text x="560" y="636" text-anchor="middle" class="ring-label">MCM</text>
+  <text x="560" y="654" text-anchor="middle" class="legend-note">2026Q1</text>
+
+  
+    <g class="project-dot">
+      <circle cx="620.60" cy="535.05" r="12.5" fill="#E8F1FF" stroke="#3B82F6" stroke-width="2.1" />
+      <text x="620.60" y="539.25" text-anchor="middle" class="dot-id">01</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="679.35" cy="618.96" r="12.5" fill="#E8F1FF" stroke="#3B82F6" stroke-width="2.1" />
+      <text x="679.35" y="623.16" text-anchor="middle" class="dot-id">02</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="701.77" cy="665.00" r="12.5" fill="#E8F1FF" stroke="#3B82F6" stroke-width="2.1" />
+      <text x="701.77" y="669.20" text-anchor="middle" class="dot-id">03</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="637.90" cy="732.84" r="12.5" fill="#E8F1FF" stroke="#3B82F6" stroke-width="2.1" />
+      <text x="637.90" y="737.04" text-anchor="middle" class="dot-id">04</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="609.24" cy="775.28" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="609.24" y="779.48" text-anchor="middle" class="dot-id">05</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="442.94" cy="671.37" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="442.94" y="675.57" text-anchor="middle" class="dot-id">06</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="416.04" cy="640.00" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="416.04" y="644.20" text-anchor="middle" class="dot-id">07</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="398.95" cy="596.85" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="398.95" y="601.05" text-anchor="middle" class="dot-id">08</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="606.72" cy="420.22" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="606.72" y="424.42" text-anchor="middle" class="dot-id">09</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="660.65" cy="413.93" r="12.5" fill="#E8F1FF" stroke="#3B82F6" stroke-width="2.1" />
+      <text x="660.65" y="418.13" text-anchor="middle" class="dot-id">10</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="718.84" cy="421.38" r="12.5" fill="#E8F1FF" stroke="#3B82F6" stroke-width="2.1" />
+      <text x="718.84" y="425.58" text-anchor="middle" class="dot-id">11</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="726.98" cy="489.65" r="12.5" fill="#E8F1FF" stroke="#3B82F6" stroke-width="2.1" />
+      <text x="726.98" y="493.85" text-anchor="middle" class="dot-id">12</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="784.69" cy="640.00" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="784.69" y="644.20" text-anchor="middle" class="dot-id">13</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="483.15" cy="851.14" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="483.15" y="855.34" text-anchor="middle" class="dot-id">14</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="400.94" cy="829.57" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="400.94" y="833.77" text-anchor="middle" class="dot-id">15</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="335.31" cy="640.00" r="12.5" fill="#E8F1FF" stroke="#3B82F6" stroke-width="2.1" />
+      <text x="335.31" y="644.20" text-anchor="middle" class="dot-id">16</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="415.57" cy="467.88" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="415.57" y="472.08" text-anchor="middle" class="dot-id">17</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="475.36" cy="407.46" r="12.5" fill="#E8F1FF" stroke="#3B82F6" stroke-width="2.1" />
+      <text x="475.36" y="411.66" text-anchor="middle" class="dot-id">18</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="672.25" cy="331.60" r="12.5" fill="#F3E8FF" stroke="#9333EA" stroke-width="2.1" />
+      <text x="672.25" y="335.80" text-anchor="middle" class="dot-id">19</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="785.59" cy="371.15" r="12.5" fill="#F3E8FF" stroke="#9333EA" stroke-width="2.1" />
+      <text x="785.59" y="375.35" text-anchor="middle" class="dot-id">20</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="888.19" cy="640.00" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="888.19" y="644.20" text-anchor="middle" class="dot-id">21</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="475.06" cy="957.01" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="475.06" y="961.21" text-anchor="middle" class="dot-id">22</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="384.52" cy="943.94" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="384.52" y="948.14" text-anchor="middle" class="dot-id">23</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="295.73" cy="904.27" r="12.5" fill="#F3E8FF" stroke="#9333EA" stroke-width="2.1" />
+      <text x="295.73" y="908.47" text-anchor="middle" class="dot-id">24</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="327.93" cy="407.93" r="12.5" fill="#F3E8FF" stroke="#9333EA" stroke-width="2.1" />
+      <text x="327.93" y="412.13" text-anchor="middle" class="dot-id">25</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="384.52" cy="336.06" r="12.5" fill="#F3E8FF" stroke="#9333EA" stroke-width="2.1" />
+      <text x="384.52" y="340.26" text-anchor="middle" class="dot-id">26</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="463.27" cy="279.00" r="12.5" fill="#E8F1FF" stroke="#3B82F6" stroke-width="2.1" />
+      <text x="463.27" y="283.20" text-anchor="middle" class="dot-id">27</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="775.85" cy="266.15" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="775.85" y="270.35" text-anchor="middle" class="dot-id">28</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="991.69" cy="640.00" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="991.69" y="644.20" text-anchor="middle" class="dot-id">29</text>
+    </g>
+  
+    <g class="project-dot">
+      <circle cx="344.15" cy="266.15" r="12.5" fill="#FFF4E8" stroke="#D97706" stroke-width="2.1" />
+      <text x="344.15" y="270.35" text-anchor="middle" class="dot-id">30</text>
+    </g>
+
+  <text x="1098" y="168" class="legend-title">Index</text>
+  <text x="1098" y="188" class="legend-note">Blend of CNCF MCM radar and non-CNCF ecosystem projects (issue #267).</text>
+  
+    <g transform="translate(1108, 208)">
+      <circle cx="0" cy="0" r="9" fill="#E8F1FF" stroke="#3B82F6" stroke-width="2" />
+      <text x="16" y="4.5" class="legend-source">CNCF</text>
+    </g>
+  
+    <g transform="translate(1328, 208)">
+      <circle cx="0" cy="0" r="9" fill="#FFF4E8" stroke="#D97706" stroke-width="2" />
+      <text x="16" y="4.5" class="legend-source">Ecosystem (Non-CNCF)</text>
+    </g>
+  
+    <g transform="translate(1548, 208)">
+      <circle cx="0" cy="0" r="9" fill="#F3E8FF" stroke="#9333EA" stroke-width="2" />
+      <text x="16" y="4.5" class="legend-source">Kubewharf Ecosystem</text>
+    </g>
+  <text x="1098" y="258" class="legend-ring-title" fill="#53A66A">ADOPT (8)</text>
+<text x="1098" y="278" class="legend-ring-desc">Production default choices for most teams</text>
+<text x="1108" y="298" class="legend-item">01 Cilium Cluster Mesh [CNCF] - Control Plane &amp; Orchestration</text>
+<text x="1108" y="318" class="legend-item">02 Argo CD [CNCF] - GitOps &amp; App Delivery</text>
+<text x="1108" y="338" class="legend-item">03 Flux CD [CNCF] - GitOps &amp; App Delivery</text>
+<text x="1108" y="358" class="legend-item">04 Cluster API [CNCF] - Cluster Lifecycle &amp; IaC</text>
+<text x="1108" y="378" class="legend-item">05 Terraform [Ecosystem (Non-CNCF)] - Cluster Lifecycle &amp; IaC</text>
+<text x="1108" y="398" class="legend-item">06 Kubernetes Dashboard [Ecosystem (Non-CNCF)] - Portal &amp; Visibility</text>
+<text x="1108" y="418" class="legend-item">07 KubeSphere Console [Ecosystem (Non-CNCF)] - Portal &amp; Visibility</text>
+<text x="1108" y="438" class="legend-item">08 Lens [Ecosystem (Non-CNCF)] - Portal &amp; Visibility</text>
+<text x="1098" y="466" class="legend-ring-title" fill="#4E7FD1">TRIAL (10)</text>
+<text x="1098" y="486" class="legend-ring-desc">Strong candidates to evaluate in production pilots</text>
+<text x="1108" y="506" class="legend-item">09 Clusternet [Ecosystem (Non-CNCF)] - Control Plane &amp; Orchestration</text>
+<text x="1108" y="526" class="legend-item">10 Karmada [CNCF] - Control Plane &amp; Orchestration</text>
+<text x="1108" y="546" class="legend-item">11 KubeStellar [CNCF] - Control Plane &amp; Orchestration</text>
+<text x="1108" y="566" class="legend-item">12 Open Cluster Management [CNCF] - Control Plane &amp; Orchestration</text>
+<text x="1108" y="586" class="legend-item">13 Fleet [Ecosystem (Non-CNCF)] - GitOps &amp; App Delivery</text>
+<text x="1108" y="606" class="legend-item">14 vCluster [Ecosystem (Non-CNCF)] - Tenancy &amp; API Virtualization</text>
+<text x="1108" y="626" class="legend-item">15 Virtual Kubelet [Ecosystem (Non-CNCF)] - Tenancy &amp; API</text>
+<text x="1108" y="642" class="legend-item">Virtualization</text>
+<text x="1108" y="662" class="legend-item">16 Headlamp [CNCF] - Portal &amp; Visibility</text>
+<text x="1108" y="682" class="legend-item">17 KWOK [Ecosystem (Non-CNCF)] - Scale Testing &amp; Scheduling</text>
+<text x="1108" y="702" class="legend-item">18 Volcano [CNCF] - Scale Testing &amp; Scheduling</text>
+<text x="1098" y="730" class="legend-ring-title" fill="#D58A39">ASSESS (9)</text>
+<text x="1098" y="750" class="legend-ring-desc">Promising options that need focused validation</text>
+<text x="1108" y="770" class="legend-item">19 KubeAdmiral [Kubewharf Ecosystem] - Control Plane &amp; Orchestration</text>
+<text x="1108" y="790" class="legend-item">20 kubeBrain [Kubewharf Ecosystem] - Control Plane &amp; Orchestration</text>
+<text x="1108" y="810" class="legend-item">21 PipeCD [Ecosystem (Non-CNCF)] - GitOps &amp; App Delivery</text>
+<text x="1108" y="830" class="legend-item">22 Kamaji [Ecosystem (Non-CNCF)] - Tenancy &amp; API Virtualization</text>
+<text x="1108" y="850" class="legend-item">23 KCP [Ecosystem (Non-CNCF)] - Tenancy &amp; API Virtualization</text>
+<text x="1108" y="870" class="legend-item">24 KubeZoo [Kubewharf Ecosystem] - Tenancy &amp; API Virtualization</text>
+<text x="1108" y="890" class="legend-item">25 Godel Scheduler [Kubewharf Ecosystem] - Scale Testing &amp; Scheduling</text>
+<text x="1108" y="910" class="legend-item">26 Katalyst [Kubewharf Ecosystem] - Scale Testing &amp; Scheduling</text>
+<text x="1108" y="930" class="legend-item">27 Koordinator [CNCF] - Scale Testing &amp; Scheduling</text>
+<text x="1098" y="958" class="legend-ring-title" fill="#CC5F5F">HOLD (3)</text>
+<text x="1098" y="978" class="legend-ring-desc">Legacy patterns to avoid for new designs</text>
+<text x="1108" y="998" class="legend-item">28 KubeFed v1 [Ecosystem (Non-CNCF)] - Control Plane &amp; Orchestration</text>
+<text x="1108" y="1018" class="legend-item">29 Custom kubeconfig fan-out scripts [Ecosystem (Non-CNCF)] - GitOps &amp;</text>
+<text x="1108" y="1034" class="legend-item">App Delivery</text>
+<text x="1108" y="1054" class="legend-item">30 Untested multi-cluster operators [Ecosystem (Non-CNCF)] - Scale</text>
+<text x="1108" y="1070" class="legend-item">Testing &amp; Scheduling</text>
+
+
+  <text x="76" y="1186" class="footer">Maintenance: edit diagrams/mcm-multicluster-radar.data.json and run node scripts/generate-mcm-radar-svg.js</text>
+  <text x="76" y="1208" class="footer">Scope: multi-cluster management for AI infra (control plane, delivery, lifecycle, tenancy, portal, and scale testing).</text>
+</svg>

--- a/docs/blog/2025-12-15/multi-tenancy-isolation.md
+++ b/docs/blog/2025-12-15/multi-tenancy-isolation.md
@@ -493,42 +493,25 @@ pool of pre-initialized sandboxed environments.
 As AI infrastructure scales, managing workloads across multiple Kubernetes clusters becomes essential for disaster
 recovery, geographic distribution, and workload isolation.
 
-### CNCF Multicluster Management (MCM) Radar 2024Q3
+### Multi-Cluster Management Radar (GitHub-Maintained, CNCF + Ecosystem)
 
-The CNCF Technology Radar provides guidance on the maturity of multicluster management solutions:
+To keep the radar maintainable in GitHub PRs, this section now uses a local data-driven SVG instead of an external
+image attachment.
 
-**Adopt** (Production-Ready):
+This updated version extends beyond CNCF items and includes non-CNCF ecosystem projects raised in issue #267:
 
-- **<a href="https://github.com/argoproj/argo-cd">Argo CD</a>** (Graduated): GitOps continuous delivery for
-  Kubernetes
-- **<a href="https://github.com/cilium/cilium">Cilium</a>** (Graduated): Multi-cluster networking with Cluster Mesh
+- Multi-cluster control planes: Karmada, Clusternet, Fleet, Open Cluster Management, KubeAdmiral
+- Delivery and lifecycle: Argo CD, Flux CD, Cluster API, Terraform, PipeCD
+- Tenancy and API virtualization: Virtual Kubelet, vCluster, KCP, Kamaji, KubeZoo
+- Portal and operational pressure points: Lens, Headlamp, Kubernetes Dashboard, KubeSphere Console, KWOK
+- Kubewharf ecosystem: kubeBrain, KubeAdmiral, KubeZoo, Godel Scheduler, Katalyst
 
-**Trial** (Evaluate for Production):
+![MCM Radar (CNCF + Ecosystem)](../../../diagrams/mcm-multicluster-radar.svg)
 
-- **<a href="https://github.com/karmada-io/karmada">Karmada</a>** (Incubating): Multi-cloud multi-cluster application
-  management
-- **<a href="https://github.com/istio/istio">Istio</a>** (Graduated): Multi-cluster service mesh
-- **<a href="https://github.com/linkerd/linkerd2">Linkerd</a>** (Graduated): Lightweight multi-cluster service mesh
-- **<a href="https://github.com/kubestellar/kubestellar">KubeStellar</a>** (Sandbox): Multi-cluster workload
-  deployment
-- **<a href="https://github.com/kubestash/kubestash">Armada</a>** (Sandbox): Batch scheduling across clusters
-- **<a href="https://github.com/backstage/backstage">Backstage</a>** (Incubating): Developer portal for multi-cluster
-  visibility
+Maintenance:
 
-**Assess** (Emerging):
-
-- **<a href="https://github.com/kubevela/kubevela">KubeVela</a>** (Incubating): Application delivery platform
-- **<a href="https://github.com/kubeedge/sedna">PipeCD</a>** (Sandbox): Progressive delivery for multi-cloud
-- **<a href="https://github.com/kuma-io/kuma">Kuma</a>** (Sandbox): Universal service mesh
-- **<a href="https://github.com/open-cluster-management-io/ocm">Meshery</a>** (Sandbox): Service mesh management plane
-- **<a href="https://github.com/clusterpedia-io/clusterpedia">Clusterpedia</a>** (Sandbox): Multi-cluster resource
-  search
-
-**Hold** (Not Recommended):
-
-- Solutions not meeting current production requirements
-
-![CNCF MCM Radar 2024Q3](https://github.com/user-attachments/assets/9a9a4222-efa6-4f4c-9878-e40ed6bb5889)
+- Source data: `diagrams/mcm-multicluster-radar.data.json`
+- Regenerate SVG: `node scripts/generate-mcm-radar-svg.js`
 
 ### Multitenancy Spectrum
 

--- a/docs/blog/2025-12-15/multi-tenancy-isolation_zh.md
+++ b/docs/blog/2025-12-15/multi-tenancy-isolation_zh.md
@@ -482,37 +482,24 @@ spec:
 
 随着 AI 基础设施的扩展,跨多个 Kubernetes 集群管理工作负载对于灾难恢复、地理分布和工作负载隔离至关重要。
 
-### CNCF 多集群管理 (MCM) 雷达图 2024Q3
+### 多集群管理雷达图 (GitHub 可维护版, CNCF + 生态项目)
 
-CNCF 技术雷达图提供了多集群管理解决方案成熟度的指导:
+为了方便在 GitHub 里通过 PR 持续维护,这里改为仓库内的数据驱动 SVG,不再依赖外链附件图片。
 
-**采用** (生产就绪):
+这个版本在 CNCF 基础上补充了 issue #267 提到的非 CNCF 项目:
 
-- **<a href="https://github.com/argoproj/argo-cd">Argo CD</a>** (已毕业):Kubernetes 的 GitOps 持续交付
-- **<a href="https://github.com/cilium/cilium">Cilium</a>** (已毕业):使用 Cluster Mesh 的多集群网络
+- 多集群控制面: Karmada、Clusternet、Fleet、Open Cluster Management、KubeAdmiral
+- 交付与生命周期: Argo CD、Flux CD、Cluster API、Terraform、PipeCD
+- 多租户与 API 虚拟化: Virtual Kubelet、vCluster、KCP、Kamaji、KubeZoo
+- 门户与运维压力点: Lens、Headlamp、Kubernetes Dashboard、KubeSphere Console、KWOK
+- Kubewharf 体系: kubeBrain、KubeAdmiral、KubeZoo、Godel Scheduler、Katalyst
 
-**试用** (评估用于生产):
+![多集群管理雷达图 (CNCF + 生态项目)](../../../diagrams/mcm-multicluster-radar.svg)
 
-- **<a href="https://github.com/karmada-io/karmada">Karmada</a>** (孵化中):多云多集群应用管理
-- **<a href="https://github.com/istio/istio">Istio</a>** (已毕业):多集群服务网格
-- **<a href="https://github.com/linkerd/linkerd2">Linkerd</a>** (已毕业):轻量级多集群服务网格
-- **<a href="https://github.com/kubestellar/kubestellar">KubeStellar</a>** (沙箱):多集群工作负载部署
-- **<a href="https://github.com/kubestash/kubestash">Armada</a>** (沙箱):跨集群批处理调度
-- **<a href="https://github.com/backstage/backstage">Backstage</a>** (孵化中):多集群可见性的开发者门户
+维护方式:
 
-**评估** (新兴):
-
-- **<a href="https://github.com/kubevela/kubevela">KubeVela</a>** (孵化中):应用交付平台
-- **<a href="https://github.com/kubeedge/sedna">PipeCD</a>** (沙箱):多云渐进式交付
-- **<a href="https://github.com/kuma-io/kuma">Kuma</a>** (沙箱):通用服务网格
-- **<a href="https://github.com/open-cluster-management-io/ocm">Meshery</a>** (沙箱):服务网格管理平面
-- **<a href="https://github.com/clusterpedia-io/clusterpedia">Clusterpedia</a>** (沙箱):多集群资源搜索
-
-**持有** (不推荐):
-
-- 不符合当前生产要求的解决方案
-
-![CNCF MCM 雷达图 2024Q3](https://github.com/user-attachments/assets/9a9a4222-efa6-4f4c-9878-e40ed6bb5889)
+- 数据源: `diagrams/mcm-multicluster-radar.data.json`
+- 生成命令: `node scripts/generate-mcm-radar-svg.js`
 
 ### 多租户范围
 

--- a/scripts/generate-mcm-radar-svg.js
+++ b/scripts/generate-mcm-radar-svg.js
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const dataPath = path.join(repoRoot, 'diagrams', 'mcm-multicluster-radar.data.json');
+const outPath = path.join(repoRoot, 'diagrams', 'mcm-multicluster-radar.svg');
+
+const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+
+const canvas = { width: 1880, height: 1260 };
+const radar = { cx: 560, cy: 640, innerRadius: 86, outerRadius: 500 };
+const legend = { x: 1080, y: 128, width: 730, height: 1010 };
+const ringThickness = (radar.outerRadius - radar.innerRadius) / data.rings.length;
+
+function escapeXml(input) {
+  return String(input)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function toRadians(deg) {
+  return (deg * Math.PI) / 180;
+}
+
+function polarToCartesian(cx, cy, r, angle) {
+  const rad = toRadians(angle);
+  return {
+    x: cx + r * Math.cos(rad),
+    y: cy + r * Math.sin(rad)
+  };
+}
+
+function sectorPath(cx, cy, inner, outer, start, end) {
+  const outerStart = polarToCartesian(cx, cy, outer, start);
+  const outerEnd = polarToCartesian(cx, cy, outer, end);
+  const innerEnd = polarToCartesian(cx, cy, inner, end);
+  const innerStart = polarToCartesian(cx, cy, inner, start);
+  const delta = ((end - start) % 360 + 360) % 360;
+  const largeArc = delta > 180 ? 1 : 0;
+
+  return [
+    `M ${outerStart.x.toFixed(2)} ${outerStart.y.toFixed(2)}`,
+    `A ${outer} ${outer} 0 ${largeArc} 1 ${outerEnd.x.toFixed(2)} ${outerEnd.y.toFixed(2)}`,
+    `L ${innerEnd.x.toFixed(2)} ${innerEnd.y.toFixed(2)}`,
+    `A ${inner} ${inner} 0 ${largeArc} 0 ${innerStart.x.toFixed(2)} ${innerStart.y.toFixed(2)}`,
+    'Z'
+  ].join(' ');
+}
+
+function wrapWords(text, maxChars) {
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines = [];
+  let current = '';
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length <= maxChars || current.length === 0) {
+      current = next;
+      continue;
+    }
+    lines.push(current);
+    current = word;
+  }
+
+  if (current) lines.push(current);
+  return lines.length ? lines : [text];
+}
+
+const rings = data.rings.map((ring, index) => {
+  const inner = radar.innerRadius + ringThickness * index;
+  const outer = radar.innerRadius + ringThickness * (index + 1);
+  return {
+    ...ring,
+    index,
+    inner,
+    outer,
+    mid: (inner + outer) / 2
+  };
+});
+
+const sectors = data.sectors.map((sector, index) => ({
+  ...sector,
+  index,
+  mid: (sector.start + sector.end) / 2
+}));
+
+const ringIndex = new Map(rings.map((ring) => [ring.id, ring.index]));
+const ringById = new Map(rings.map((ring) => [ring.id, ring]));
+const sectorIndex = new Map(sectors.map((sector) => [sector.id, sector.index]));
+const sectorById = new Map(sectors.map((sector) => [sector.id, sector]));
+
+const projects = data.projects
+  .slice()
+  .sort((a, b) => {
+    const ringDiff = (ringIndex.get(a.ring) ?? 999) - (ringIndex.get(b.ring) ?? 999);
+    if (ringDiff !== 0) return ringDiff;
+    const sectorDiff = (sectorIndex.get(a.sector) ?? 999) - (sectorIndex.get(b.sector) ?? 999);
+    if (sectorDiff !== 0) return sectorDiff;
+    return a.name.localeCompare(b.name, 'en', { sensitivity: 'base' });
+  });
+
+const grouped = new Map();
+for (const project of projects) {
+  const key = `${project.ring}::${project.sector}`;
+  const arr = grouped.get(key) || [];
+  arr.push(project);
+  grouped.set(key, arr);
+}
+
+const radialSteps = [0.34, 0.56, 0.78];
+const placedProjects = [];
+
+for (const [key, groupProjects] of grouped.entries()) {
+  const [ringId, sectorId] = key.split('::');
+  const ring = ringById.get(ringId);
+  const sector = sectorById.get(sectorId);
+  if (!ring || !sector) continue;
+
+  const total = groupProjects.length;
+  for (let i = 0; i < total; i += 1) {
+    const project = groupProjects[i];
+    const angle =
+      typeof project.angle === 'number'
+        ? project.angle
+        : sector.start + ((i + 1) / (total + 1)) * (sector.end - sector.start);
+    const radial =
+      typeof project.radial === 'number' ? project.radial : radialSteps[i % radialSteps.length];
+    const radius = ring.inner + radial * (ring.outer - ring.inner);
+    const point = polarToCartesian(radar.cx, radar.cy, radius, angle);
+    placedProjects.push({
+      ...project,
+      ring,
+      sector,
+      source: data.sources[project.source] || data.sources.ecosystem,
+      angle,
+      radius,
+      x: point.x,
+      y: point.y
+    });
+  }
+}
+
+placedProjects.sort((a, b) => {
+  const ringDiff = a.ring.index - b.ring.index;
+  if (ringDiff !== 0) return ringDiff;
+  const sectorDiff = a.sector.index - b.sector.index;
+  if (sectorDiff !== 0) return sectorDiff;
+  return a.name.localeCompare(b.name, 'en', { sensitivity: 'base' });
+});
+
+for (let i = 0; i < placedProjects.length; i += 1) {
+  placedProjects[i].id = String(i + 1).padStart(2, '0');
+}
+
+const sectorBackgrounds = sectors
+  .map((sector, index) => {
+    const fill = index % 2 === 0 ? '#FAFCFF' : '#F7FAFC';
+    return `<path d="${sectorPath(
+      radar.cx,
+      radar.cy,
+      radar.innerRadius,
+      radar.outerRadius,
+      sector.start,
+      sector.end
+    )}" fill="${fill}" />`;
+  })
+  .join('\n  ');
+
+const ringCircles = rings
+  .map(
+    (ring) =>
+      `<circle cx="${radar.cx}" cy="${radar.cy}" r="${ring.outer.toFixed(2)}" fill="${ring.fill}" fill-opacity="0.36" stroke="${ring.stroke}" stroke-width="1.4" />`
+  )
+  .reverse()
+  .join('\n  ');
+
+const ringBoundaries = rings
+  .map(
+    (ring) =>
+      `<circle cx="${radar.cx}" cy="${radar.cy}" r="${ring.outer.toFixed(
+        2
+      )}" fill="none" stroke="#8A94A6" stroke-width="0.8" stroke-dasharray="4 5" />`
+  )
+  .join('\n  ');
+
+const sectorLines = sectors
+  .map((sector) => {
+    const start = polarToCartesian(radar.cx, radar.cy, radar.innerRadius, sector.start);
+    const end = polarToCartesian(radar.cx, radar.cy, radar.outerRadius, sector.start);
+    return `<line x1="${start.x.toFixed(2)}" y1="${start.y.toFixed(2)}" x2="${end.x.toFixed(
+      2
+    )}" y2="${end.y.toFixed(2)}" stroke="#99A3B2" stroke-width="1.1" />`;
+  })
+  .join('\n  ');
+
+const sectorLabels = sectors
+  .map((sector) => {
+    const pos = polarToCartesian(radar.cx, radar.cy, radar.outerRadius + 34, sector.mid);
+    const cos = Math.cos(toRadians(sector.mid));
+    const anchor = cos > 0.24 ? 'start' : cos < -0.24 ? 'end' : 'middle';
+    return `<text x="${pos.x.toFixed(2)}" y="${(pos.y + 4).toFixed(2)}" text-anchor="${anchor}" class="sector-label">${escapeXml(
+      sector.label
+    )}</text>`;
+  })
+  .join('\n  ');
+
+const ringLabels = rings
+  .map((ring) => {
+    const pos = polarToCartesian(radar.cx, radar.cy, ring.mid, -104);
+    return `<text x="${(pos.x - 12).toFixed(2)}" y="${(pos.y + 4).toFixed(
+      2
+    )}" text-anchor="end" class="ring-label">${escapeXml(ring.label)}</text>`;
+  })
+  .join('\n  ');
+
+const projectDots = placedProjects
+  .map((project) => {
+    return `
+    <g class="project-dot">
+      <circle cx="${project.x.toFixed(2)}" cy="${project.y.toFixed(2)}" r="12.5" fill="${project.source.fill}" stroke="${project.source.stroke}" stroke-width="2.1" />
+      <text x="${project.x.toFixed(2)}" y="${(project.y + 4.2).toFixed(2)}" text-anchor="middle" class="dot-id">${project.id}</text>
+    </g>`;
+  })
+  .join('\n  ');
+
+const sourceLegendEntries = Object.entries(data.sources)
+  .map(([id, source], index) => {
+    const x = legend.x + 28 + index * 220;
+    const y = legend.y + 80;
+    return `
+    <g transform="translate(${x}, ${y})">
+      <circle cx="0" cy="0" r="9" fill="${source.fill}" stroke="${source.stroke}" stroke-width="2" />
+      <text x="16" y="4.5" class="legend-source">${escapeXml(source.label)}</text>
+    </g>`;
+  })
+  .join('\n  ');
+
+const projectsByRing = new Map(rings.map((ring) => [ring.id, []]));
+for (const project of placedProjects) {
+  projectsByRing.get(project.ring.id).push(project);
+}
+
+let legendY = legend.y + 130;
+let ringDetails = '';
+
+for (const ring of rings) {
+  const items = projectsByRing.get(ring.id) || [];
+  ringDetails += `<text x="${legend.x + 18}" y="${legendY}" class="legend-ring-title" fill="${
+    ring.stroke
+  }">${escapeXml(ring.label)} (${items.length})</text>\n`;
+  legendY += 20;
+  ringDetails += `<text x="${legend.x + 18}" y="${legendY}" class="legend-ring-desc">${escapeXml(
+    ring.description
+  )}</text>\n`;
+  legendY += 20;
+
+  for (const item of items) {
+    const line = `${item.id} ${item.name} [${item.source.label}] - ${item.sector.label}`;
+    const wrapped = wrapWords(line, 70);
+    for (const wrappedLine of wrapped) {
+      ringDetails += `<text x="${legend.x + 28}" y="${legendY}" class="legend-item">${escapeXml(
+        wrappedLine
+      )}</text>\n`;
+      legendY += 16;
+    }
+    legendY += 4;
+  }
+
+  legendY += 8;
+}
+
+const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${canvas.width}" height="${canvas.height}" viewBox="0 0 ${canvas.width} ${canvas.height}" role="img" aria-labelledby="title desc">
+  <title id="title">${escapeXml(data.meta.title)} (${escapeXml(data.meta.version)})</title>
+  <desc id="desc">Multi-cluster management technology radar generated from JSON data for easy GitHub maintenance.</desc>
+  <defs>
+    <style>
+      .title { font: 700 42px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .subtitle { font: 500 19px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #4B5563; }
+      .sector-label { font: 600 13px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #334155; }
+      .ring-label { font: 700 14px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #475569; letter-spacing: 0.6px; }
+      .dot-id { font: 700 10.5px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .legend-title { font: 700 24px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #111827; }
+      .legend-note { font: 500 13.5px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #4B5563; }
+      .legend-source { font: 600 13px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #334155; }
+      .legend-ring-title { font: 700 16px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; }
+      .legend-ring-desc { font: 500 12.5px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #64748B; }
+      .legend-item { font: 500 12.5px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #1F2937; }
+      .footer { font: 500 13px ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif; fill: #64748B; }
+    </style>
+  </defs>
+
+  <rect x="0" y="0" width="${canvas.width}" height="${canvas.height}" fill="#F3F5F8" />
+  <rect x="${legend.x}" y="${legend.y}" width="${legend.width}" height="${legend.height}" rx="16" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1.4" />
+
+  <text x="76" y="72" class="title">${escapeXml(data.meta.title)}</text>
+  <text x="76" y="102" class="subtitle">${escapeXml(data.meta.version)} | updated ${escapeXml(
+    data.meta.last_updated
+  )}</text>
+
+  ${sectorBackgrounds}
+  ${ringCircles}
+  ${ringBoundaries}
+  ${sectorLines}
+  ${sectorLabels}
+  ${ringLabels}
+
+  <circle cx="${radar.cx}" cy="${radar.cy}" r="${radar.innerRadius - 2}" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1.2" />
+  <text x="${radar.cx}" y="${radar.cy - 4}" text-anchor="middle" class="ring-label">MCM</text>
+  <text x="${radar.cx}" y="${radar.cy + 14}" text-anchor="middle" class="legend-note">2026Q1</text>
+
+  ${projectDots}
+
+  <text x="${legend.x + 18}" y="${legend.y + 40}" class="legend-title">Index</text>
+  <text x="${legend.x + 18}" y="${legend.y + 60}" class="legend-note">Blend of CNCF MCM radar and non-CNCF ecosystem projects (issue #267).</text>
+  ${sourceLegendEntries}
+  ${ringDetails}
+
+  <text x="76" y="1186" class="footer">Maintenance: edit diagrams/mcm-multicluster-radar.data.json and run node scripts/generate-mcm-radar-svg.js</text>
+  <text x="76" y="1208" class="footer">Scope: multi-cluster management for AI infra (control plane, delivery, lifecycle, tenancy, portal, and scale testing).</text>
+</svg>
+`;
+
+fs.writeFileSync(outPath, svg);
+console.log(`Generated ${path.relative(repoRoot, outPath)} from ${path.relative(repoRoot, dataPath)}`);


### PR DESCRIPTION
## Summary
- switch MCM radar to logo-first rendering (project blips use logos instead of text-only dots)
- add local logo assets under diagrams/logos/mcm and embed them into generated SVG for GitHub-safe rendering
- generate two outputs from one data source:
  - diagrams/mcm-multicluster-radar.svg (EN)
  - diagrams/mcm-multicluster-radar.zh-CN.svg (ZH, project names unchanged)
- update EN/ZH docs references and maintenance instructions

## Validation
- node scripts/generate-mcm-radar-svg.js

Closes #267