### PR TITLE
docs(case-study): add cloud-native company case-study drafts

### DIFF
--- a/case-study/README.md
+++ b/case-study/README.md
@@ -1,0 +1,21 @@
+# Cloud Native Case Study（初稿）
+
+本目录先做“公司-项目清单”版本：每个文件对应一家厂商，先罗列其发起项目与深度参与项目。
+
+## 公司列表
+
+- [字节跳动](./bytedance.md)
+- [华为](./huawei.md)
+- [DaoCloud](./daocloud.md)
+- [阿里巴巴](./alibaba.md)
+- [腾讯](./tencent.md)
+- [Google](./google.md)
+- [Azure（Microsoft）](./azure.md)
+- [Red Hat](./redhat.md)
+- [AWS](./aws.md)
+- [NVIDIA](./nvidia.md)
+
+## 说明
+
+- 字节与华为文件包含了按层对照的简版分析。
+- 其余文件当前为“先简单罗列项目”的版本，后续可补贡献强度与生态关系图。

--- a/case-study/alibaba.md
+++ b/case-study/alibaba.md
@@ -1,0 +1,18 @@
+# 阿里巴巴（Alibaba）云原生开源案例（初稿）
+
+## 发起/主导项目（代表）
+
+- [openkruise/kruise](https://github.com/openkruise/kruise)
+- [kubevela/kubevela](https://github.com/kubevela/kubevela)
+- [alibaba/higress](https://github.com/alibaba/higress)
+- [koordinator-sh/koordinator](https://github.com/koordinator-sh/koordinator)
+- [fluid-cloudnative/fluid](https://github.com/fluid-cloudnative/fluid)
+- [dragonflyoss/dragonfly](https://github.com/dragonflyoss/dragonfly)
+- [openyurtio/openyurt](https://github.com/openyurtio/openyurt)
+- [alibaba/nacos](https://github.com/alibaba/nacos)
+- [alibaba/Sentinel](https://github.com/alibaba/Sentinel)
+
+## 深度参与项目（代表）
+
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [istio/istio](https://github.com/istio/istio)

--- a/case-study/aws.md
+++ b/case-study/aws.md
@@ -1,0 +1,17 @@
+# AWS 云原生开源案例（初稿）
+
+## 发起/主导项目（代表）
+
+- [aws/eks-distro](https://github.com/aws/eks-distro)
+- [aws/eks-anywhere](https://github.com/aws/eks-anywhere)
+- [kubernetes-sigs/karpenter](https://github.com/kubernetes-sigs/karpenter)
+- [aws/karpenter-provider-aws](https://github.com/aws/karpenter-provider-aws)
+- [aws-controllers-k8s/community](https://github.com/aws-controllers-k8s/community)
+- [bottlerocket-os/bottlerocket](https://github.com/bottlerocket-os/bottlerocket)
+- [firecracker-microvm/firecracker](https://github.com/firecracker-microvm/firecracker)
+- [awslabs/soci-snapshotter](https://github.com/awslabs/soci-snapshotter)
+
+## 深度参与项目（代表）
+
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [containerd/containerd](https://github.com/containerd/containerd)

--- a/case-study/azure.md
+++ b/case-study/azure.md
@@ -1,0 +1,15 @@
+# Azure（Microsoft）云原生开源案例（初稿）
+
+## 发起/共同发起项目（代表）
+
+- [dapr/dapr](https://github.com/dapr/dapr)
+- [kedacore/keda](https://github.com/kedacore/keda)
+- [virtual-kubelet/virtual-kubelet](https://github.com/virtual-kubelet/virtual-kubelet)
+- [openservicemesh/osm](https://github.com/openservicemesh/osm)
+- [Azure/azure-service-operator](https://github.com/Azure/azure-service-operator)
+- [kubevela/kubevela](https://github.com/kubevela/kubevela)
+
+## 深度参与项目（代表）
+
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [istio/istio](https://github.com/istio/istio)

--- a/case-study/bytedance.md
+++ b/case-study/bytedance.md
@@ -1,0 +1,30 @@
+# 字节跳动（ByteDance）云原生开源案例（初稿）
+
+## 参考输入
+
+- 你提供的文章链接：https://mp.weixin.qq.com/s/fUK6qqcFzkoNcscHBE9v8A
+- 你提供的分层图（KubeBrain / Godel / Katalyst / kubeadmiral / podseidon / kelemetry 等）
+
+## 分层视角（基于你给的图和字节方案）
+
+- 多集群与联邦层：`kubeadmiral`、`podseidon`
+- 入口与治理层：`kubegateway`、`kubezoo`
+- 核心控制面层：`kubebrain`（元信息存储）、`godel-scheduler`（调度）
+- 节点与数据面层：`katalyst-core`
+- 跨层可观测层：`kelemetry`
+
+## 发起/主导项目（代表）
+
+- [kubewharf/kubebrain](https://github.com/kubewharf/kubebrain)
+- [kubewharf/godel-scheduler](https://github.com/kubewharf/godel-scheduler)
+- [kubewharf/katalyst-core](https://github.com/kubewharf/katalyst-core)
+- [kubewharf/kubeadmiral](https://github.com/kubewharf/kubeadmiral)
+- [kubewharf/podseidon](https://github.com/kubewharf/podseidon)
+- [kubewharf/kubegateway](https://github.com/kubewharf/kubegateway)
+- [kubewharf/kubezoo](https://github.com/kubewharf/kubezoo)
+- [kubewharf/kelemetry](https://github.com/kubewharf/kelemetry)
+
+## 深度参与项目（代表）
+
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [istio/istio](https://github.com/istio/istio)

--- a/case-study/daocloud.md
+++ b/case-study/daocloud.md
@@ -1,0 +1,15 @@
+# DaoCloud 云原生开源案例（初稿）
+
+## 发起/主导项目（代表）
+
+- [knoway-dev/knoway](https://github.com/knoway-dev/knoway)
+- [merbridge/merbridge](https://github.com/merbridge/merbridge)
+- [spidernet-io/spiderpool](https://github.com/spidernet-io/spiderpool)
+- [hwameistor/hwameistor](https://github.com/hwameistor/hwameistor)
+- [kdoctor-io/kdoctor](https://github.com/kdoctor-io/kdoctor)
+- [clusterpedia-io/clusterpedia](https://github.com/clusterpedia-io/clusterpedia)
+
+## 深度参与项目（代表）
+
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [istio/istio](https://github.com/istio/istio)

--- a/case-study/google.md
+++ b/case-study/google.md
@@ -1,0 +1,16 @@
+# Google 云原生开源案例（初稿）
+
+## 发起/共同发起项目（代表）
+
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [istio/istio](https://github.com/istio/istio)
+- [knative/serving](https://github.com/knative/serving)
+- [google/gvisor](https://github.com/google/gvisor)
+- [google/cadvisor](https://github.com/google/cadvisor)
+- [bazelbuild/bazel](https://github.com/bazelbuild/bazel)
+- [tektoncd/pipeline](https://github.com/tektoncd/pipeline)
+
+## 深度参与项目（代表）
+
+- [containerd/containerd](https://github.com/containerd/containerd)
+- [etcd-io/etcd](https://github.com/etcd-io/etcd)

--- a/case-study/huawei.md
+++ b/case-study/huawei.md
@@ -1,0 +1,33 @@
+# 华为云（Huawei）云原生开源案例（初稿）
+
+## 分析基线
+
+- 对照基线：字节分层方案（你提供的链接 + 分层图）
+- 本文聚焦你点名的华为相关项目：`Karmada`、`Volcano`（含 `kthena/agentcube`）、`KubeEdge`、`kmesh`、`kuasar`、`vllm-ascend`、`openGemini`、`Sermant`
+
+## 与字节方案的分层对照（简版）
+
+- 多集群与联邦：字节 `kubeadmiral/podseidon`；华为 `Karmada`
+- 调度与编排：字节 `godel-scheduler`；华为 `Volcano`（并扩展 `kthena/agentcube`）
+- 节点/运行时与边云：字节 `katalyst-core`；华为 `KubeEdge`、`kuasar`
+- 服务治理：字节 `kubegateway/kubezoo`；华为 `kmesh`、`Sermant`
+- 可观测/数据底座：字节 `kelemetry`；华为 `openGemini`
+- AI 推理适配：华为侧代表项目 `vllm-ascend`
+
+## 发起/主导项目（代表）
+
+- [karmada-io/karmada](https://github.com/karmada-io/karmada)
+- [volcano-sh/volcano](https://github.com/volcano-sh/volcano)
+- [volcano-sh/kthena](https://github.com/volcano-sh/kthena)
+- [volcano-sh/agentcube](https://github.com/volcano-sh/agentcube)
+- [kubeedge/kubeedge](https://github.com/kubeedge/kubeedge)
+- [kmesh-net/kmesh](https://github.com/kmesh-net/kmesh)
+- [kuasar-io/kuasar](https://github.com/kuasar-io/kuasar)
+- [vllm-project/vllm-ascend](https://github.com/vllm-project/vllm-ascend)
+- [openGemini/openGemini](https://github.com/openGemini/openGemini)
+- [sermant-io/Sermant](https://github.com/sermant-io/Sermant)
+
+## 深度参与项目（代表）
+
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [istio/istio](https://github.com/istio/istio)

--- a/case-study/nvidia.md
+++ b/case-study/nvidia.md
@@ -1,0 +1,17 @@
+# NVIDIA 云原生开源案例（初稿）
+
+## 发起/主导项目（代表）
+
+- [NVIDIA/gpu-operator](https://github.com/NVIDIA/gpu-operator)
+- [NVIDIA/k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin)
+- [NVIDIA/dcgm-exporter](https://github.com/NVIDIA/dcgm-exporter)
+- [NVIDIA/nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit)
+- [NVIDIA/TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM)
+- [triton-inference-server/server](https://github.com/triton-inference-server/server)
+- [NVIDIA/nccl](https://github.com/NVIDIA/nccl)
+- [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo)
+
+## 深度参与项目（代表）
+
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [containerd/containerd](https://github.com/containerd/containerd)

--- a/case-study/redhat.md
+++ b/case-study/redhat.md
@@ -1,0 +1,15 @@
+# Red Hat 云原生开源案例（初稿）
+
+## 发起/主导项目（代表）
+
+- [openshift/origin](https://github.com/openshift/origin)
+- [operator-framework/operator-sdk](https://github.com/operator-framework/operator-sdk)
+- [operator-framework/operator-lifecycle-manager](https://github.com/operator-framework/operator-lifecycle-manager)
+- [kubevirt/kubevirt](https://github.com/kubevirt/kubevirt)
+- [cri-o/cri-o](https://github.com/cri-o/cri-o)
+- [kedacore/keda](https://github.com/kedacore/keda)
+
+## 深度参与项目（代表）
+
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [istio/istio](https://github.com/istio/istio)

--- a/case-study/tencent.md
+++ b/case-study/tencent.md
@@ -1,0 +1,14 @@
+# 腾讯（Tencent）云原生开源案例（初稿）
+
+## 发起/主导项目（代表）
+
+- [TarsCloud/Tars](https://github.com/TarsCloud/Tars)
+- [tkestack/tke](https://github.com/tkestack/tke)
+- [superedge/superedge](https://github.com/superedge/superedge)
+- [polarismesh/polaris](https://github.com/polarismesh/polaris)
+- [TencentBlueKing/bk-bcs](https://github.com/TencentBlueKing/bk-bcs)
+
+## 深度参与项目（代表）
+
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [istio/istio](https://github.com/istio/istio)


### PR DESCRIPTION
## Summary
- create case-study/ directory with per-company markdown files
- add ByteDance layered analysis draft based on provided reference link and architecture map
- add Huawei layered comparison draft and project list
- add initial project-list drafts for DaoCloud, Alibaba, Tencent, Google, Azure, Red Hat, AWS, and NVIDIA

## Notes
- this PR is intentionally a first-pass inventory (project list + simple mapping), to be expanded in follow-up iterations
