### PR TITLE
docs(case-study): refresh redhat leadership and participation sections

### DIFF
--- a/case-study/alibaba.md
+++ b/case-study/alibaba.md
@@ -4,6 +4,7 @@
 
 - `Higress`：新晋 CNCF Sandbox（API Gateway 方向）
 - `Kata Containers`：容器隔离与安全运行时领域的重要项目
+- `SGLang / RBG`：补充 AI 推理引擎与请求批处理/路由能力（纳入本图）
 
 ## 可编辑架构分层图（Mermaid）
 
@@ -12,6 +13,11 @@ flowchart TB
   subgraph ENTRY["入口与应用交付面"]
     HIG["⭐ Higress<br/>AI / API Gateway"]
     KVL["KubeVela<br/>Application Delivery Control Plane"]
+  end
+
+  subgraph AI["AI 推理与请求路由面"]
+    SGL["SGLang<br/>LLM Serving Engine"]
+    RBG["RBG<br/>Request Batching / Routing Gateway"]
   end
 
   subgraph CTRL["工作负载与资源控制面"]
@@ -48,6 +54,9 @@ flowchart TB
   K8S --> FLUID
   ISTIO --> K8S
   HIG --> ISTIO
+  HIG --> RBG
+  RBG --> SGL
+  SGL --> K8S
 
   %% collaboration / ecosystem integrations
   KVL -. often drives .-> OKR
@@ -67,7 +76,7 @@ flowchart TB
   classDef base fill:#e8fff1,stroke:#16a34a,color:#14532d,stroke-width:1.3px;
 
   class HIG,KRD,KATA,K8S star;
-  class KVL,OKR,OY,COC,CB,FLUID,DFLY,NACOS,SENT,ISTIO normal;
+  class KVL,OKR,OY,COC,CB,FLUID,DFLY,NACOS,SENT,ISTIO,SGL,RBG normal;
 ```
 
 ## 发起/主导项目（代表）
@@ -84,6 +93,11 @@ flowchart TB
 - [dragonflyoss/dragonfly](https://github.com/dragonflyoss/dragonfly)
 - [alibaba/nacos](https://github.com/alibaba/nacos)
 - [alibaba/Sentinel](https://github.com/alibaba/Sentinel)
+
+## 补充：AI 推理生态项目（本图纳入）
+
+- [sgl-project/sglang](https://github.com/sgl-project/sglang)
+- [sgl-project/rbg](https://github.com/sgl-project/rbg)
 
 ## 深度参与项目（代表）
 

--- a/case-study/bytedance.md
+++ b/case-study/bytedance.md
@@ -9,6 +9,7 @@
 
 - 多集群与联邦层：`kubeadmiral`、`podseidon`
 - 入口与治理层：`kubegateway`、`kubezoo`
+- AI 服务编排层：`aibrix`、`kuberay`
 - 核心控制面层：`kubebrain`（元信息存储）、`godel-scheduler`（调度）
 - 节点与数据面层：`katalyst-core`
 - 跨层可观测层：`kelemetry`
@@ -25,6 +26,11 @@ flowchart TB
   subgraph L2["Access & Governance Layer (入口与治理层)"]
     KGW["2. KubeGateway<br/>七层网关（L7入口）"]
     KZZ["3. KubeZoo<br/>轻量级多租户（租户隔离）"]
+  end
+
+  subgraph L2_5["AI Serving Layer (AI 服务编排层)"]
+    AIB["AIBrix<br/>AI Gateway / Inference Infra"]
+    KRAY["KubeRay<br/>Ray on Kubernetes"]
   end
 
   subgraph L3["Core Control Plane Layer (核心控制面层)"]
@@ -59,6 +65,9 @@ flowchart TB
   PS -. 保护多集群 .-> KA
   KGW --> KAS
   KZZ --> KAS
+  KGW --> AIB
+  AIB --> KRAY
+  KRAY --> KAS
   KCM --> KAS
   KSCH --> KAS
   GODEL --> KAS
@@ -73,7 +82,7 @@ flowchart TB
   classDef backend fill:#f5f5f5,stroke:#666,color:#333,stroke-width:1px;
 
   class KAS,KCM,KSCH,KLET std;
-  class KA,PS,KGW,KZZ,GODEL,KB,KAT,KEL bt;
+  class KA,PS,KGW,KZZ,AIB,KRAY,GODEL,KB,KAT,KEL bt;
   class TIKV,BKV backend;
 ```
 
@@ -93,3 +102,5 @@ flowchart TB
 - [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
 - [istio/istio](https://github.com/istio/istio)
 - [etcd-io/etcd](https://github.com/etcd-io/etcd)
+- [vllm-project/aibrix](https://github.com/vllm-project/aibrix)
+- [ray-project/kuberay](https://github.com/ray-project/kuberay)

--- a/case-study/redhat.md
+++ b/case-study/redhat.md
@@ -35,6 +35,8 @@ flowchart LR
   subgraph ECO["生态集成 / 深度参与（非 Red Hat 主导）"]
     ETCD["etcd"]
     KN["Knative"]
+    KSERVE["KServe"]
+    LLMD["llm-d"]
     ISTIO["Istio"]
     ARGO["Argo"]
     PROM["Prometheus"]
@@ -58,17 +60,21 @@ flowchart LR
 
   K8S -. control-plane storage .-> ETCD
   OCP -. ecosystem integration .-> KN
+  OCP -. model serving integration .-> KSERVE
+  OCP -. disaggregated inference orchestration .-> LLMD
   OCP -. service mesh integration .-> ISTIO
   OCP -. GitOps / delivery .-> ARGO
   OCP -. observability .-> PROM
   OCP -. tracing .-> JAE
+  KSERVE -. builds on .-> KN
+  LLMD -. runs on .-> K8S
 
   classDef rh fill:#fff2e6,stroke:#d97706,color:#7c2d12,stroke-width:1.4px;
   classDef eco fill:#eef4ff,stroke:#4f81bd,color:#1b2a41,stroke-width:1px;
   classDef prod fill:#f5f5f5,stroke:#666,color:#222,stroke-dasharray: 5 3;
 
   class OKD,OCM,OF,SDK,OLM,OH,KV,CRIO,KEDA,KONV,M3 rh;
-  class ETCD,K8S,KN,ISTIO,ARGO,PROM,JAE eco;
+  class ETCD,K8S,KN,KSERVE,LLMD,ISTIO,ARGO,PROM,JAE eco;
   class OCP prod;
 ```
 
@@ -103,6 +109,8 @@ flowchart LR
 - [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
 - [etcd-io/etcd](https://github.com/etcd-io/etcd)
 - [knative/serving](https://github.com/knative/serving)
+- [kserve/kserve](https://github.com/kserve/kserve)
+- [llm-d/llm-d](https://github.com/llm-d/llm-d)
 - [istio/istio](https://github.com/istio/istio)
 - [argoproj/argo-workflows](https://github.com/argoproj/argo-workflows)
 - [prometheus/prometheus](https://github.com/prometheus/prometheus)


### PR DESCRIPTION
## Summary
- restructure Red Hat case study into three sections:
  - founding/leading representative projects
  - founding/leading or strong Red Hat lineage projects
  - deep participation projects (not framed as Red Hat-led)
- add requested projects and links: OpenShift/OKD, Open Cluster Management, Operator Framework stack, KubeVirt, CRI-O, KEDA, Konveyor, Metal3
- expand deep participation list with Kubernetes, etcd, Knative, Istio, Argo, Prometheus, Jaeger

## Scope
- docs only
