### PR TITLE
docs(swap): add kubelet swap status blog and ops guide

### DIFF
--- a/docs/blog/2026-04-01/2026-04-01-kubernetes-swap-status-kubelet-and-memory-pressure.md
+++ b/docs/blog/2026-04-01/2026-04-01-kubernetes-swap-status-kubelet-and-memory-pressure.md
@@ -1,0 +1,214 @@
+---
+status: Active
+maintainer: pacoxu
+date: 2026-04-01
+tags: kubernetes, kubelet, swap, memory-pressure, sig-node, eviction, scheduling
+canonical_path: docs/blog/2026-04-01/2026-04-01-kubernetes-swap-status-kubelet-and-memory-pressure.md
+source_urls:
+  - https://github.com/kubernetes/enhancements/issues/2400
+  - https://github.com/kubernetes/enhancements/issues/5359
+  - https://github.com/kubernetes/enhancements/issues/5424
+  - https://github.com/kubernetes/enhancements/issues/5433
+  - https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2400-node-swap
+  - https://kubernetes.io/docs/concepts/cluster-administration/swap-memory-management/
+  - https://kubernetes.io/docs/reference/node/swap-behavior/
+  - https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+  - https://kubernetes.io/blog/2023/08/24/swap-linux-beta/
+  - https://kubernetes.io/blog/2025/03/25/swap-linux-improvements/
+  - https://kubernetes.io/blog/2025/08/19/tuning-linux-swap-for-kubernetes-a-deep-dive/
+  - https://www.youtube.com/watch?v=bFrEPfls5PQ
+  - https://www.youtube.com/watch?v=El94Z0JowF0
+---
+
+# Kubernetes Swap Status in 2026: kubelet behavior, memory pressure, and what is next
+
+This post summarizes the current status of swap in Kubernetes and kubelet, mainly around KEP-2400 and related follow-up enhancements.
+
+All status statements below are checked as of **2026-04-01**.
+
+## TL;DR
+
+- `KEP-2400` (Node memory swap support) is **done and closed**.
+  - Enhancement issue: `#2400` closed on **2025-09-17**.
+  - KEP status is `implemented`, `stage: stable`, latest milestone `v1.34`.
+- `NodeSwap` is already listed as **GA in Kubernetes 1.34**.
+- Current kubelet model is intentionally conservative:
+  - `NoSwap` is default behavior.
+  - `LimitedSwap` is opt-in.
+  - swap for workloads is Linux + cgroup v2 only.
+- The next big step is not “turn swap on”, but “make scheduling/eviction/workload APIs swap-aware”.
+  - `#5359` workload-controlled swap
+  - `#5424` swap-aware scheduling
+  - `#5433` swap-aware evictions
+
+## 1) Current status snapshot
+
+### KEP-2400
+
+- Issue: [kubernetes/enhancements#2400](https://github.com/kubernetes/enhancements/issues/2400)
+- Title: `Node memory swap support`
+- State: `CLOSED`
+- Closed at: **2025-09-17**
+- Labels include: `sig/node`, `stage/stable`
+- Milestone: `v1.34`
+
+### Follow-up enhancement issues (WIP)
+
+- [#5359 Workload Controlled Swap](https://github.com/kubernetes/enhancements/issues/5359)
+  - State: `OPEN`
+  - Labels include `stage/alpha`, `tracked/no`
+  - Updated: **2026-02-12**
+- [#5424 Swap-Aware Scheduling](https://github.com/kubernetes/enhancements/issues/5424)
+  - State: `OPEN`
+  - Currently placeholder-level content
+  - Updated: **2026-03-16**
+- [#5433 Swap-Aware Evictions](https://github.com/kubernetes/enhancements/issues/5433)
+  - State: `OPEN`
+  - Currently placeholder-level content
+  - Updated: **2026-01-20**
+
+## 2) Timeline: how we got here
+
+- **v1.22 (Alpha)**: initial NodeSwap support path starts.
+- **v1.28 (Beta1)**:
+  - Linux swap support promoted to beta.
+  - cgroup v2 support hardened.
+  - swap metrics exposed via `/metrics/resource` and `/stats/summary`.
+  - At that time, `UnlimitedSwap` / `LimitedSwap` behavior still appeared in docs/blog context.
+- **v1.30-v1.33 (Beta2/Beta3)**:
+  - behavior tightened toward safer defaults.
+  - `NoSwap` becomes default direction for workloads.
+  - high-priority workloads restricted from swap.
+  - memory-backed volume `noswap` handling improved.
+- **v1.34 (Stable/GA)**:
+  - KEP-2400 reaches stable and is marked implemented.
+  - Feature gates reference lists `NodeSwap` as GA starting 1.34.
+
+## 3) kubelet behavior now (practical model)
+
+For Linux nodes, kubelet swap behavior is controlled mainly by:
+
+1. `failSwapOn`
+2. `memorySwap.swapBehavior`
+
+Example:
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+failSwapOn: false
+memorySwap:
+  swapBehavior: NoSwap
+```
+
+Available behaviors now:
+
+- `NoSwap` (default): Kubernetes-managed workloads do not use swap.
+- `LimitedSwap`: workloads can use swap with Kubernetes rules.
+
+Important constraints in current design:
+
+- Workload swap support is for **Linux + cgroup v2** path.
+- Under `LimitedSwap`, swap amount is auto-calculated from memory request proportion:
+
+```text
+containerSwapLimit = (containerMemoryRequest / nodeTotalMemory) * totalPodsSwapAvailable
+```
+
+- This is why KEP-2400 is a node-level baseline capability, not the final per-workload policy framework.
+
+## 4) Observability and ops signals you should watch
+
+Kubelet/metrics now make swap visible enough for production debugging:
+
+- `/metrics/resource`
+  - `node_swap_usage_bytes`
+  - `container_swap_usage_bytes`
+  - `container_swap_limit_bytes`
+- `/stats/summary`
+- `kubectl top --show-swap`
+- node status swap capacity (`node.status.nodeInfo.swap.capacity`)
+
+Useful commands:
+
+```bash
+kubectl top nodes --show-swap
+kubectl top pods -A --show-swap
+kubectl get nodes -o go-template='{{range .items}}{{.metadata.name}}: {{if .status.nodeInfo.swap.capacity}}{{.status.nodeInfo.swap.capacity}}{{else}}<unknown>{{end}}{{"\n"}}{{end}}'
+```
+
+## 5) Memory pressure handling: kernel vs kubelet
+
+The strongest practical lesson from the 2025 deep-dive and talks is:
+
+- Kubernetes eviction and Linux reclaim/swap are related but different loops.
+- If tuning is poor, OOM killer may happen before kubelet eviction finishes.
+
+Key Linux tuning knobs repeatedly highlighted:
+
+- `vm.swappiness`
+- `vm.min_free_kbytes`
+- `vm.watermark_scale_factor`
+
+A commonly cited starting point (must be workload-tested):
+
+- `vm.swappiness = 60`
+- `vm.min_free_kbytes` around 2-3% of node memory
+- `vm.watermark_scale_factor` significantly above default (for a wider reclaim runway)
+
+And the Kubernetes-side reminder from docs:
+
+- tune eviction thresholds with awareness of kernel reclaim thresholds (`min_free_kbytes`) so swapping has room to work before hard failure.
+
+## 6) What is still missing in upstream behavior
+
+KEP-2400 intentionally did **not** solve everything:
+
+- scheduler still does not fully account for swap as a scheduling resource
+- eviction logic is not fully swap-aware by default policy
+- pod/workload-level swap policies are still evolving
+
+That gap is exactly why the follow-up issues exist:
+
+- [#5359](https://github.com/kubernetes/enhancements/issues/5359): workload/pod-level swap controls
+- [#5424](https://github.com/kubernetes/enhancements/issues/5424): scheduling awareness
+- [#5433](https://github.com/kubernetes/enhancements/issues/5433): eviction awareness
+
+## 7) Notes from the two conference slide decks
+
+Two practical themes from the conference materials are useful when planning
+production rollout:
+
+- **KubeCon NA 2025 deep dive**:
+  - reinforces the 1.22 -> 1.34 journey and the same three future tracks
+    (workload control, eviction awareness, scheduling awareness)
+  - emphasizes the OOM-vs-eviction race and “early reclaim runway” tuning via
+    `vm.min_free_kbytes` and `vm.watermark_scale_factor`
+- **KubeCon EU 2024 talk (Intel)**:
+  - frames swap design as six control questions: what/how much/where/when/how
+    to isolate effects/where control logic should live
+  - highlights out-of-tree approaches (NRI plugins + memtierd) for process- or
+    container-granularity policies that are not yet native in core Kubernetes
+
+## 8) Recommended adoption path (2026)
+
+1. Start with `NoSwap` + `failSwapOn: false` to validate node/system behavior first.
+2. Move selective node pools to `LimitedSwap` (not whole fleet at once).
+3. Keep control-plane nodes conservative (often no swap).
+4. Prefer fast, isolated swap backing storage; encrypt swap.
+5. Protect system daemons from swap / I/O starvation.
+6. Enable swap dashboards and alerts before larger rollout.
+7. Tune kernel reclaim + kubelet eviction together, not separately.
+
+## References
+
+- Main enhancement issue: [KEP-2400 issue](https://github.com/kubernetes/enhancements/issues/2400)
+- KEP text: [keps/sig-node/2400-node-swap](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2400-node-swap)
+- Official docs: [Swap memory management](https://kubernetes.io/docs/concepts/cluster-administration/swap-memory-management/)
+- Official docs: [Linux Node Swap Behaviors](https://kubernetes.io/docs/reference/node/swap-behavior/)
+- Feature gates reference: [NodeSwap GA timeline](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
+- Blog: [Kubernetes 1.28 Beta support for using swap on Linux](https://kubernetes.io/blog/2023/08/24/swap-linux-beta/)
+- Blog: [Fresh Swap Features for Linux Users in Kubernetes 1.32](https://kubernetes.io/blog/2025/03/25/swap-linux-improvements/)
+- Blog: [Tuning Linux Swap for Kubernetes: A Deep Dive](https://kubernetes.io/blog/2025/08/19/tuning-linux-swap-for-kubernetes-a-deep-dive/)
+- Talk: [Deep Dive: Handling Kubernetes Memory Pressure & Achieving Workload Stability With Swap](https://www.youtube.com/watch?v=bFrEPfls5PQ)
+- Talk: [Swap Smart, Save Big](https://www.youtube.com/watch?v=El94Z0JowF0)

--- a/docs/blog/2026-04-01/2026-04-01-kubernetes-swap-status-kubelet-memory-pressure_zh.md
+++ b/docs/blog/2026-04-01/2026-04-01-kubernetes-swap-status-kubelet-memory-pressure_zh.md
@@ -1,0 +1,208 @@
+---
+status: Active
+maintainer: pacoxu
+date: 2026-04-01
+tags: kubernetes, kubelet, swap, memory-pressure, sig-node, eviction, scheduling
+canonical_path: docs/blog/2026-04-01/2026-04-01-kubernetes-swap-status-kubelet-memory-pressure_zh.md
+source_urls:
+  - https://github.com/kubernetes/enhancements/issues/2400
+  - https://github.com/kubernetes/enhancements/issues/5359
+  - https://github.com/kubernetes/enhancements/issues/5424
+  - https://github.com/kubernetes/enhancements/issues/5433
+  - https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2400-node-swap
+  - https://kubernetes.io/docs/concepts/cluster-administration/swap-memory-management/
+  - https://kubernetes.io/docs/reference/node/swap-behavior/
+  - https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+  - https://kubernetes.io/blog/2023/08/24/swap-linux-beta/
+  - https://kubernetes.io/blog/2025/03/25/swap-linux-improvements/
+  - https://kubernetes.io/blog/2025/08/19/tuning-linux-swap-for-kubernetes-a-deep-dive/
+  - https://www.youtube.com/watch?v=bFrEPfls5PQ
+  - https://www.youtube.com/watch?v=El94Z0JowF0
+---
+
+# Kubernetes Swap 现状（2026）：kubelet 行为、内存压力与场景化落地
+
+这篇文章聚焦 Kubernetes 中 swap 的当前状态，重点围绕 `KEP-2400`、kubelet 当前行为边界，以及在不同业务场景下如何落地。
+
+文中状态信息核对时间为 **2026-04-01**。
+
+## 先说结论
+
+- `KEP-2400`（Node memory swap support）已经完成：
+  - issue `#2400` 已关闭（**2025-09-17**）。
+  - KEP 状态为 `implemented`，阶段 `stable`，里程碑 `v1.34`。
+- `NodeSwap` 在 Feature Gates 页面中已经标记为 **1.34 GA**。
+- kubelet 当前默认策略是“保守可控”：
+  - 默认 `NoSwap`，可选 `LimitedSwap`；
+  - 工作负载 swap 路径依赖 Linux + cgroup v2。
+- 下一阶段重点不是“能不能开 swap”，而是“是否具备工作负载级可控能力”：
+  - `#5359` workload controlled swap
+  - `#5424` swap-aware scheduling
+  - `#5433` swap-aware evictions
+
+## 1. 当前状态快照
+
+### 1.1 KEP-2400
+
+- Issue: [kubernetes/enhancements#2400](https://github.com/kubernetes/enhancements/issues/2400)
+- 标题: `Node memory swap support`
+- 状态: `CLOSED`
+- 关闭时间: **2025-09-17**
+- 标签: `sig/node`, `stage/stable`
+- 里程碑: `v1.34`
+
+### 1.2 仍在推进的三条后续线
+
+- [#5359 Workload Controlled Swap](https://github.com/kubernetes/enhancements/issues/5359)
+  - `OPEN`，当前仍是 alpha 早期推进态
+- [#5424 Swap-Aware Scheduling](https://github.com/kubernetes/enhancements/issues/5424)
+  - `OPEN`，目前内容仍偏占位
+- [#5433 Swap-Aware Evictions](https://github.com/kubernetes/enhancements/issues/5433)
+  - `OPEN`，目前内容仍偏占位
+
+## 2. kubelet 现在到底怎么工作
+
+对 Linux 节点，核心开关主要有两个：
+
+1. `failSwapOn`
+2. `memorySwap.swapBehavior`
+
+示例（允许 kubelet 在有 swap 的节点启动，但默认不给 workload 用）：
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+failSwapOn: false
+memorySwap:
+  swapBehavior: NoSwap
+```
+
+可选行为：
+
+- `NoSwap`（默认）: Kubernetes 管理的 workload 不使用 swap。
+- `LimitedSwap`: workload 在规则约束下可使用 swap。
+
+在 `LimitedSwap` 下，容器 swap 上限按请求占比自动计算：
+
+```text
+containerSwapLimit = (containerMemoryRequest / nodeTotalMemory) * totalPodsSwapAvailable
+```
+
+这也是为什么 `KEP-2400` 解决的是“节点级基础能力”，而不是“完整工作负载级策略控制”。
+
+## 3. 场景化落地（结合两份 KubeCon slides）
+
+下面把“是否该开 swap”拆成更具体的 4 类场景。
+
+### 场景 A：成本/密度导向的离线或弱实时池
+
+典型特征：
+
+- 业务常见“内存 request 偏保守”，但活跃工作集并不一直顶满；
+- 对 tail latency 不极致敏感；
+- 更关心单位节点承载和资源成本。
+
+对应到 `Swap Smart, Save Big`（KubeCon EU 2024）的核心观点：
+
+- 同样物理内存下，通过回收“低活跃页”有机会提升承载密度。
+- 实际价值来自“减少过度 request 带来的空转内存”。
+
+落地建议：
+
+- 先在专用 worker pool 试点 `LimitedSwap`，不要全局一键开启。
+- swap 盘优先 SSD/NVMe，尽量与业务 I/O 隔离。
+- 对该池做容量收益与延迟退化的双指标评估。
+
+### 场景 B：内存突刺导致 OOMKill 先于 Eviction
+
+典型特征：
+
+- 节点在压力突刺时出现 `OOMKilled`；
+- kubelet eviction 来不及触发或触发太晚；
+- 表现为“偶发雪崩、恢复慢”。
+
+对应 `Deep Dive: Handling Kubernetes Memory Pressure...`（KubeCon NA 2025）与官方调优博客的核心经验：
+
+- 只开 swap 不够，必须配套内核回收参数与 eviction 阈值。
+- `vm.min_free_kbytes`、`vm.watermark_scale_factor` 决定 reclaim “提前量”和“跑道长度”。
+
+落地建议：
+
+- 先把内核回收窗口调到可观测可控，再调整 kubelet eviction 阈值。
+- 重点观察 OOM 与 Evicted 的比例变化，而不是只看 swap 使用率。
+- 压测覆盖“渐进负载 + 突刺负载”两种模式。
+
+### 场景 C：控制面与系统关键组件保护
+
+典型特征：
+
+- 控制面和系统守护进程稳定性优先级极高；
+- 不能接受 swap 带来的随机 I/O 抖动。
+
+官方文档和两份 slides 都强调：
+
+- 控制面节点建议保持保守（通常不启用 workload swap）。
+- 系统关键进程要避免被 swap 和 I/O 争抢拖慢。
+
+落地建议：
+
+- 系统关键 daemons（如 kubelet/container runtime）设置更严格保护。
+- 提升 system slice I/O 优先级，避免 swap I/O 抢占关键路径。
+- 把 swap 策略与节点角色绑定，不要同一模板覆盖所有节点。
+
+### 场景 D：需要更细粒度控制（容器/进程级）
+
+典型特征：
+
+- 你希望做到 QoS 之外的细粒度策略，例如按容器、按进程、按空闲时长控制 pageout。
+
+EU 2024 slides 的结论是：
+
+- 社区已有 NRI + memtierd 等 out-of-tree 方案可实验；
+- 但 upstream 原生能力仍在演进，尚未形成统一稳定 API。
+
+落地建议：
+
+- 生产主路径先用 upstream 已稳定能力；
+- 细粒度策略先在实验池验证，再决定是否平台化。
+
+## 4. 可观测与验证清单
+
+至少覆盖以下信号：
+
+- kubelet `/metrics/resource`:
+  - `node_swap_usage_bytes`
+  - `container_swap_usage_bytes`
+  - `container_swap_limit_bytes`
+- kubelet `/stats/summary`
+- `kubectl top --show-swap`
+- node status swap capacity
+
+常用命令：
+
+```bash
+kubectl top nodes --show-swap
+kubectl top pods -A --show-swap
+kubectl get nodes -o go-template='{{range .items}}{{.metadata.name}}: {{if .status.nodeInfo.swap.capacity}}{{.status.nodeInfo.swap.capacity}}{{else}}<unknown>{{end}}{{"\n"}}{{end}}'
+```
+
+## 5. 建议的推进顺序（2026）
+
+1. 从 `NoSwap + failSwapOn: false` 起步，先验证节点级稳定性。
+2. 仅在目标池灰度 `LimitedSwap`，并绑定明确业务场景。
+3. 同步调优内核 reclaim 参数与 kubelet eviction 阈值。
+4. 以“稳定性 + 成本收益”双指标决定是否扩面。
+5. 关注 `#5359/#5424/#5433` 进展，预留后续策略升级空间。
+
+## 参考
+
+- [KEP-2400 Issue](https://github.com/kubernetes/enhancements/issues/2400)
+- [KEP-2400 Design](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2400-node-swap)
+- [Swap memory management docs](https://kubernetes.io/docs/concepts/cluster-administration/swap-memory-management/)
+- [Linux Node Swap Behaviors](https://kubernetes.io/docs/reference/node/swap-behavior/)
+- [Feature Gates: NodeSwap](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
+- [Kubernetes 1.28: swap beta](https://kubernetes.io/blog/2023/08/24/swap-linux-beta/)
+- [Fresh Swap Features for Linux Users in Kubernetes 1.32](https://kubernetes.io/blog/2025/03/25/swap-linux-improvements/)
+- [Tuning Linux Swap for Kubernetes: A Deep Dive](https://kubernetes.io/blog/2025/08/19/tuning-linux-swap-for-kubernetes-a-deep-dive/)
+- [Deep Dive: Handling Kubernetes Memory Pressure & Achieving Workload Stability With Swap](https://www.youtube.com/watch?v=bFrEPfls5PQ)
+- [Swap Smart, Save Big](https://www.youtube.com/watch?v=El94Z0JowF0)

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -28,6 +28,20 @@ from PR #281 into production scenarios:
 - **Not only acceleration**: introduces workaround paths (VPA and in-place Pod
   container restarts in v1.35) to reduce unnecessary full cold starts.
 
+## 2026-04-01: Kubernetes Swap Status in 2026
+
+- [Kubernetes Swap Status in 2026: kubelet behavior, memory pressure, and what is next](./2026-04-01/2026-04-01-kubernetes-swap-status-kubelet-and-memory-pressure.md)
+
+An up-to-date status summary of Kubernetes swap support with a practical
+operations lens:
+
+- **Current status**: KEP-2400 is implemented and closed; NodeSwap is GA in 1.34
+- **kubelet behavior today**: `NoSwap` vs `LimitedSwap`, Linux + cgroup v2 path
+- **Operational focus**: observability endpoints, `kubectl top --show-swap`,
+  and memory-pressure tuning boundaries
+- **Roadmap gap**: workload-controlled swap, swap-aware scheduling, and
+  swap-aware evictions tracked in #5359/#5424/#5433
+
 ## 2026-03-24: Maintenance Scan (Outdated Resources + Safe Upgrades)
 
 Implemented in this cleanup:

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -31,6 +31,7 @@ from PR #281 into production scenarios:
 ## 2026-04-01: Kubernetes Swap Status in 2026
 
 - [Kubernetes Swap Status in 2026: kubelet behavior, memory pressure, and what is next](./2026-04-01/2026-04-01-kubernetes-swap-status-kubelet-and-memory-pressure.md)
+- [Kubernetes Swap 现状（2026）：kubelet 行为、内存压力与场景化落地 (Chinese)](./2026-04-01/2026-04-01-kubernetes-swap-status-kubelet-memory-pressure_zh.md)
 
 An up-to-date status summary of Kubernetes swap support with a practical
 operations lens:
@@ -41,6 +42,9 @@ operations lens:
   and memory-pressure tuning boundaries
 - **Roadmap gap**: workload-controlled swap, swap-aware scheduling, and
   swap-aware evictions tracked in #5359/#5424/#5433
+- **Scenario-oriented guidance**: converts conference materials into concrete
+  rollout scenarios (cost density, memory spikes, control-plane protection,
+  and fine-grained policy exploration)
 
 ## 2026-03-24: Maintenance Scan (Outdated Resources + Safe Upgrades)
 

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2025-12-17
+last_updated: 2026-04-01
 tags: kubernetes, ai-infrastructure, scheduling, resource-management
 canonical_path: docs/kubernetes/README.md
 ---
@@ -36,6 +36,9 @@ workload isolation.
   guide covering high-throughput scheduling, multi-scheduler patterns,
   gang scheduling, topology-aware scheduling, load balancing, and
   descheduling strategies
+- **[Swap Memory Management](./swap-memory-management.md)**: Practical guide to
+  kubelet swap behaviors (`NoSwap`/`LimitedSwap`), observability, and memory
+  pressure tuning in Kubernetes
 - **[Dynamic Resource Allocation (DRA)](./dra.md)**: Flexible device
   allocation with structured parameters and topology awareness
 - **[NVIDIA GPU Operator](./nvidia-gpu-operator.md)**: Automated GPU driver
@@ -76,6 +79,8 @@ workload isolation.
    for GPU resource management
 3. Explore [NRI](./nri.md) for fine-grained container control
 4. Understand [Pod Lifecycle](./pod-lifecycle.md) for debugging
+5. Use [Swap Memory Management](./swap-memory-management.md) when tuning
+   kubelet behavior under memory pressure
 
 ### For Platform Engineers
 

--- a/docs/kubernetes/swap-memory-management.md
+++ b/docs/kubernetes/swap-memory-management.md
@@ -1,0 +1,130 @@
+---
+status: Active
+maintainer: pacoxu
+last_updated: 2026-04-01
+tags: kubernetes, kubelet, swap, memory-management, cgroupv2, eviction
+canonical_path: docs/kubernetes/swap-memory-management.md
+---
+
+# Kubernetes Swap Memory Management
+
+This page is a practical companion for operating swap-enabled Kubernetes Linux nodes.
+
+Status in this page is aligned to upstream state as of **2026-04-01**.
+
+## Current Upstream Status
+
+- `KEP-2400` ([issue #2400](https://github.com/kubernetes/enhancements/issues/2400)) is complete.
+  - stage: stable
+  - KEP status: implemented
+  - milestone: v1.34
+- Follow-up items are still in progress:
+  - [#5359 Workload Controlled Swap](https://github.com/kubernetes/enhancements/issues/5359)
+  - [#5424 Swap-Aware Scheduling](https://github.com/kubernetes/enhancements/issues/5424)
+  - [#5433 Swap-Aware Evictions](https://github.com/kubernetes/enhancements/issues/5433)
+
+## Prerequisites
+
+- Linux nodes
+- cgroup v2 for workload swap support path
+- swap already provisioned on host (file or partition)
+
+## Kubelet Configuration
+
+### Baseline (allow kubelet start, keep workloads non-swap)
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+failSwapOn: false
+memorySwap:
+  swapBehavior: NoSwap
+```
+
+### Enable workload swap
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+failSwapOn: false
+memorySwap:
+  swapBehavior: LimitedSwap
+```
+
+## Behavior Model
+
+- `NoSwap` (default): Kubernetes-managed workloads do not use swap.
+- `LimitedSwap`: workloads can use swap under kubelet/CRI rules.
+- Swap allocation is automatic and request-proportional (under current model):
+
+```text
+containerSwapLimit = (containerMemoryRequest / nodeTotalMemory) * totalPodsSwapAvailable
+```
+
+- Current implementation is intentionally conservative and not yet full workload-level policy control.
+
+## Observability
+
+### Kubelet endpoints and metrics
+
+- `/metrics/resource`
+  - `node_swap_usage_bytes`
+  - `container_swap_usage_bytes`
+  - `container_swap_limit_bytes`
+- `/stats/summary`
+
+### Useful commands
+
+```bash
+kubectl top nodes --show-swap
+kubectl top pods -A --show-swap
+kubectl get nodes -o go-template='{{range .items}}{{.metadata.name}}: {{if .status.nodeInfo.swap.capacity}}{{.status.nodeInfo.swap.capacity}}{{else}}<unknown>{{end}}{{"\n"}}{{end}}'
+```
+
+### Discover nodes with swap via NFD label
+
+```bash
+kubectl get nodes -o jsonpath='{range .items[?(@.metadata.labels.feature\.node\.kubernetes\.io/memory-swap)]}{.metadata.name}{"\t"}{.metadata.labels.feature\.node\.kubernetes\.io/memory-swap}{"\n"}{end}'
+```
+
+## Memory Pressure Tuning Guidance
+
+Use kernel reclaim and kubelet eviction together as one control loop.
+
+Key knobs:
+
+- `vm.swappiness`
+- `vm.min_free_kbytes`
+- `vm.watermark_scale_factor`
+- kubelet eviction thresholds (`memory.available`)
+
+Common starting point from SIG Node deep-dive materials (benchmark before production rollout):
+
+- `vm.swappiness = 60`
+- `vm.min_free_kbytes` around 2-3% of physical memory
+- `vm.watermark_scale_factor` significantly above default to widen reclaim runway
+
+Operational goals:
+
+- start reclaim/swap early enough to avoid hard OOM spikes
+- avoid reclaim so early that workloads thrash and latency collapses
+- keep kubelet eviction and kernel reclaim thresholds aligned
+
+## Risks and Guardrails
+
+- Swap can degrade latency if active working set is swapped.
+- Poor tuning can cause OOM before kubelet eviction completes.
+- Scheduler is not fully swap-aware yet.
+- Encrypt swap where possible.
+- Prefer isolated and fast backing storage (SSD/NVMe).
+- Protect system-critical daemons from swap and I/O starvation.
+
+## Related Reading
+
+- [Kubernetes swap memory management docs](https://kubernetes.io/docs/concepts/cluster-administration/swap-memory-management/)
+- [Linux node swap behaviors](https://kubernetes.io/docs/reference/node/swap-behavior/)
+- [KEP-2400 issue](https://github.com/kubernetes/enhancements/issues/2400)
+- [KEP-2400 design](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2400-node-swap)
+- [Kubernetes 1.28 swap beta blog](https://kubernetes.io/blog/2023/08/24/swap-linux-beta/)
+- [Kubernetes 1.32 swap improvements blog](https://kubernetes.io/blog/2025/03/25/swap-linux-improvements/)
+- [Linux swap tuning deep dive](https://kubernetes.io/blog/2025/08/19/tuning-linux-swap-for-kubernetes-a-deep-dive/)


### PR DESCRIPTION
## Summary
- add a new long-form blog post on Kubernetes swap status (`KEP-2400`) with verified timeline and current state
- add a new Kubernetes reference page for swap operations and memory-pressure tuning
- update docs indexes in `docs/blog/README.md` and `docs/kubernetes/README.md`

## Details
- new blog: `docs/blog/2026-04-01/2026-04-01-kubernetes-swap-status-kubelet-and-memory-pressure.md`
- new guide: `docs/kubernetes/swap-memory-management.md`
- include current status for follow-up enhancements:
  - `#5359` workload-controlled swap
  - `#5424` swap-aware scheduling
  - `#5433` swap-aware evictions
- include practical signals and ops commands for swap observability (`/metrics/resource`, `/stats/summary`, `kubectl top --show-swap`)
- include notes distilled from provided KubeCon slides plus official Kubernetes docs/blogs

## Scope
- docs only (no runtime code changes)
