### PR TITLE
docs(roadmap): add sanitized executable backlog and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-execution-item.yaml
+++ b/.github/ISSUE_TEMPLATE/roadmap-execution-item.yaml
@@ -1,0 +1,106 @@
+name: Roadmap Execution Item
+description: Create an executable issue from the AI-Infra roadmap backlog.
+title: "[Backlog] <ID> <short title>"
+labels:
+  - status/needs-design
+body:
+  - type: input
+    id: backlog_id
+    attributes:
+      label: Backlog ID
+      description: Use the ID from the backlog (for example C01, O01, T13).
+      placeholder: C01
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - scheduling
+        - inference
+        - observability
+        - security
+        - agent-infra
+        - multi-cluster
+        - storage
+        - tooling
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0 (this month)
+        - P1 (this quarter)
+        - P2 (later)
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Describe the current failure mode and impact.
+      placeholder: |
+        What is failing now?
+        Who is affected?
+        Why do we need this now?
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal_non_goal
+    attributes:
+      label: Goal / Non-Goal
+      placeholder: |
+        Goal:
+        - ...
+        Non-goal:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables (with paths)
+      description: List expected docs/scripts/config outputs.
+      placeholder: |
+        - docs/...
+        - scripts/...
+        - configs/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Include run command + expected result.
+      placeholder: |
+        - [ ] Command:
+        - [ ] Expected output/state:
+        - [ ] Negative test:
+    validations:
+      required: true
+
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risks and Dependencies
+      placeholder: |
+        - Upstream version dependency:
+        - Environment prerequisite:
+        - Potential regression:
+
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback / Cleanup
+      placeholder: |
+        - Revert steps:
+        - Resource cleanup commands:

--- a/.github/ISSUE_TEMPLATE/topic-proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/topic-proposal.yaml
@@ -1,0 +1,65 @@
+name: Topic Proposal
+description: Propose a new AI-Infra topic for roadmap or backlog.
+title: "[Topic] <short title>"
+labels:
+  - status/needs-design
+body:
+  - type: input
+    id: topic_name
+    attributes:
+      label: Topic Name
+      placeholder: Agent runtime guardrails
+    validations:
+      required: true
+
+  - type: textarea
+    id: pain_point
+    attributes:
+      label: Pain Point
+      description: What production problem does this topic solve?
+      placeholder: Describe failure mode and business impact.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: expected_track
+    attributes:
+      label: Expected Track
+      options:
+        - docs/kubernetes
+        - docs/inference
+        - docs/training
+        - docs/observability
+        - agent-infra
+        - case-study
+        - scripts/configs
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_outputs
+    attributes:
+      label: Proposed Outputs
+      placeholder: |
+        - doc path:
+        - script/config path:
+        - demo scope:
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      placeholder: |
+        - [ ] Minimal reproducible path
+        - [ ] Verification commands
+        - [ ] Rollback or cleanup path
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: Primary References
+      description: Official docs/spec links only.

--- a/RoadMap.md
+++ b/RoadMap.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-03-03
+last_updated: 2026-04-03
 tags: roadmap, planning, future-work, ai-native
 ---
 
@@ -52,6 +52,20 @@ This repository is evolving to address the key challenges of the AI Native era:
 
 The following topics are planned for future addition to the repository,
 organized by AI Native focus areas:
+
+### 🔧 Execution Backlog (Sanitized, 2026 Q2)
+
+For actionable items that can be converted directly into issues, use:
+[Executable Backlog 2026 Q2](./docs/planning/executable-backlog-2026Q2.md).
+
+Execution rhythm for this quarter:
+
+- **Wave 1 (Weeks 1-4)**: Agent observability + runtime security baseline + eval gate
+- **Wave 2 (Weeks 5-8)**: Scheduling controls + inference conformance gate
+- **Wave 3 (Weeks 9-12)**: Multi-cluster burst + model storage baseline
+
+RoadMap keeps strategic direction; the backlog document tracks item-level
+execution and acceptance criteria.
 
 ### AI Native Platform
 
@@ -401,11 +415,11 @@ contribute learning materials, please:
 
 **This roadmap is reviewed and updated every quarter** to ensure it remains
 current with the rapidly evolving AI infrastructure landscape. The next
-scheduled review is planned for Q1 2026.
+scheduled review is planned for Q2 2026.
 
 If you notice that items on this roadmap have become outdated or if you'd like
 to propose new topics, please open an issue or submit a pull request.
 
 ---
 
-Last updated: 2026-03-03
+Last updated: 2026-04-03

--- a/docs/planning/executable-backlog-2026Q2.md
+++ b/docs/planning/executable-backlog-2026Q2.md
@@ -1,0 +1,118 @@
+---
+status: Active
+maintainer: pacoxu
+last_updated: 2026-04-03
+tags: roadmap, backlog, execution, issues, ai-native
+canonical_path: docs/planning/executable-backlog-2026Q2.md
+---
+
+# AI-Infra 可执行 Backlog（脱敏版，2026 Q2）
+
+## 1. 文档目的
+
+把外部研究输入整理成可直接执行的仓库任务，优先形成：
+
+- 可提交的文档增量（`docs/*`、`agent-infra/*`、`case-study/*`）
+- 可复用配置/脚本骨架（`scripts/*`、`configs/*`）
+- 可追踪的 issue 列表（按条目 ID 拆分）
+
+## 2. 脱敏规则
+
+本版已执行以下脱敏：
+
+- 移除检索痕迹、引用占位符、对话系统标记。
+- 移除与仓库落地无关的外部上下文描述，仅保留可执行任务。
+- 将“建议路径”重映射为当前仓库结构，不强制新增 `talks/` 顶层。
+- 对“状态可能变化”的事实加上快照日期，避免长期误用。
+
+## 3. 执行优先级（主题级）
+
+| ID | 主题 | 优先级 | 目标产物 | 建议落位 |
+| --- | --- | --- | --- | --- |
+| T01 | DRA GPU 身份治理 | High | 门禁说明 + RBAC/Webhook 样例 + 回收脚本 | `docs/kubernetes/` + `scripts/` |
+| T02 | LLM/SLM 混合路由 | Medium | 路由策略文档 + 最小 router demo | `docs/inference/` + `scripts/` |
+| T03 | Agent 可观测（OTel GenAI） | High | trace/metric 规范 + 回放脚本 | `docs/observability/` |
+| T04 | Pre-generative Agent 设计 | Low | PRD 模板 + 设计评审清单 | `docs/` + `templates` 型文档 |
+| T05 | Air-gapped LLM 平台 | Medium | 离线部署与同步流程 | `docs/kubernetes/` + `scripts/` |
+| T06 | K8s 实验跟踪（MLflow） | Medium | 架构文档 + 最小部署样例 | `docs/training/` |
+| T07 | AI right-sizing 闭环 | Medium | case study + baseline 策略 | `case-study/` + `docs/observability/` |
+| T08 | SLM 训练推理一体 | High | QLoRA + serving + autoscaling 路径 | `docs/training/` + `docs/inference/` |
+| T09 | Agent 驱动 Terraform→Crossplane 迁移 | Medium | 迁移 PRD 模板 + loop 流程 | `docs/kubernetes/` + `scripts/` |
+| T10 | 平台内自治 Agent 治理 | High | 最小权限/隔离/审计基线 | `agent-infra/` + `docs/kubernetes/` |
+| T11 | MCP 授权与 CIMD | Medium | 授权流程说明 + 示例配置 | `agent-infra/` |
+| T12 | Envoy AI Gateway | High | token/cost-aware 网关样例 | `docs/inference/` |
+| T13 | 推理 Conformance 门禁 | High | preflight checklist + probes/gate 模板 | `docs/inference/` + `scripts/` |
+
+## 4. Top 12（建议先开 issue）
+
+以下条目按“先可观测/安全/评测，再扩展调度与多集群”的原则排序。
+
+### Wave 1（第 1-4 周）：可观测 + 安全 + 评测
+
+1. `[O01]` OTel GenAI 语义规范落地（Status 快照见第 6 节）
+2. `[O03]` vLLM 指标与仪表盘对齐
+3. `[H03]` Agent 运行命名空间 PSS 基线
+4. `[H04]` Seccomp `RuntimeDefault` 默认化
+5. `[E06]` LLM 系统级 evals CI 门禁
+
+### Wave 2（第 5-8 周）：调度 + 推理可靠性
+
+1. `[C01]` Kueue GPU 队列与配额治理
+2. `[C02]` DRA ResourceClaim 生命周期与权限边界
+3. `[C07]` PD 拆分实验与 TTFT/ITL 对照
+4. `[T13]` 推理 preflight + admission gate 最小集
+
+### Wave 3（第 9-12 周）：跨集群 + 存储统一
+
+1. `[N01]` 多集群虚拟节点池化（最小 PoC）
+2. `[N04]` 跨集群统一排队策略
+3. `[D01]` 模型权重统一存储与挂载基线
+
+## 5. Issue 切分格式（统一 DoD）
+
+每个 issue 使用以下结构：
+
+1. 背景与问题：当前失败模式、影响范围、为什么现在做。  
+2. 目标与非目标：这次只交付什么，不交付什么。  
+3. 交付物：文档/脚本/配置/示例输出路径。  
+4. 验收标准：可执行命令 + 可观察结果 + 失败回滚路径。  
+5. 风险与依赖：上游版本、CRD 稳定性、环境前置条件。  
+
+Definition of Done（统一）：
+
+- 至少 1 个主文档更新（含背景、方案、边界、风险）。
+- 至少 1 个可运行入口（脚本或命令序列）。
+- 至少 1 组验证步骤（成功与失败各 1 条）。
+- 明确回滚/清理命令。
+
+## 6. 事实状态快照（需要定期复核）
+
+以下结论仅作为本次规划快照，日期：`2026-04-03`。
+
+- DRA：按 Kubernetes 文档相关页面，设备分配能力处于稳定阶段。
+- OTel GenAI Semantic Conventions：仍在 Development 阶段。
+- MCP 授权中的 CIMD：规范鼓励 client/auth server 支持。
+- Keycloak 在 MCP 场景下的 CIMD：以“计划支持”作为风险前提处理。
+
+建议在每次季度规划时重审此节。
+
+## 7. 仓库落地映射（首批文件建议）
+
+为兼容当前仓库结构，首批优先新增/更新以下文件：
+
+- `docs/observability/agent-otel-genai.md`
+- `docs/kubernetes/dra-identity-governance.md`
+- `docs/kubernetes/agent-runtime-guardrails.md`
+- `docs/inference/inference-conformance.md`
+- `docs/inference/envoy-ai-gateway.md`
+- `docs/training/slm-finetune-serving.md`
+- `agent-infra/mcp-auth-cimd.md`
+- `case-study/telco-rightsizing.md`
+- `scripts/conformance/preflight.sh`
+- `scripts/airgapped/sync-models.sh`
+
+## 8. 维护方式
+
+- RoadMap 只保留方向与阶段目标，本文件维护执行条目与拆分粒度。
+- 每个条目状态建议采用：`todo` / `in-progress` / `done` / `blocked`。
+- 每月末更新一次本文件的 Top 12 排序与状态。


### PR DESCRIPTION
## Summary
- add sanitized executable backlog for 2026 Q2 at docs/planning/executable-backlog-2026Q2.md
- link roadmap to backlog and add quarterly execution waves
- add issue template for backlog execution items
- add issue template for new topic proposals

## Notes
- only roadmap, backlog, and issue-template files are included in this PR
- existing local changes in README files, case-study/daocloud.md, and archive/c-ray are intentionally excluded

## Validation
- reviewed markdown structure and metadata fields
- verified RoadMap link points to the new backlog document
