### PR TITLE
docs: sync release references for tracked AI Infra projects

### DIFF
--- a/agent-infra/runtime-benchmark.md
+++ b/agent-infra/runtime-benchmark.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-03-25
+last_updated: 2026-04-06
 tags: agent-sandbox, benchmark, runtime, gvisor, kata-containers, runc, vm, performance
 canonical_path: agent-infra/runtime-benchmark.md
 ---
@@ -51,7 +51,7 @@ selection for production deployments.
 | gVisor (runsc) version | 20240318 |
 | Kata Containers version | 3.5 (kata-qemu) |
 | VM baseline | Dedicated GCE VM (same machine type, Docker CE) |
-| Image | `ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.1.0` |
+| Image | `ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.2.1` |
 | SandboxWarmPool size | 5 (for warm-start experiments) |
 | Experiment rounds | 3 (results below are median across rounds) |
 

--- a/agent-infra/scripts/agent-sandbox-benchmark/k8s/warmpool-gvisor.yaml
+++ b/agent-infra/scripts/agent-sandbox-benchmark/k8s/warmpool-gvisor.yaml
@@ -12,7 +12,7 @@ spec:
         runtimeClassName: gvisor
         containers:
           - name: agent
-            image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.1.0
+            image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.2.1
             resources:
               requests:
                 cpu: "150m"

--- a/agent-infra/scripts/agent-sandbox-benchmark/k8s/warmpool-kata.yaml
+++ b/agent-infra/scripts/agent-sandbox-benchmark/k8s/warmpool-kata.yaml
@@ -12,7 +12,7 @@ spec:
         runtimeClassName: kata-qemu
         containers:
           - name: agent
-            image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.1.0
+            image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.2.1
             resources:
               requests:
                 cpu: "200m"

--- a/agent-infra/scripts/agent-sandbox-benchmark/k8s/warmpool-runc.yaml
+++ b/agent-infra/scripts/agent-sandbox-benchmark/k8s/warmpool-runc.yaml
@@ -11,7 +11,7 @@ spec:
       spec:
         containers:
           - name: agent
-            image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.1.0
+            image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.2.1
             resources:
               requests:
                 cpu: "100m"

--- a/agent-infra/scripts/agent-sandbox-benchmark/run-benchmark.sh
+++ b/agent-infra/scripts/agent-sandbox-benchmark/run-benchmark.sh
@@ -108,7 +108,7 @@ spec:
       runtimeClassName: ${runtime_class}
       containers:
       - name: agent
-        image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.1.0
+        image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.2.1
         command: ["sleep", "${sleep_secs}"]
 YAML
   else
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
       - name: agent
-        image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.1.0
+        image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.2.1
         command: ["sleep", "${sleep_secs}"]
 YAML
   fi

--- a/agent-infra/scripts/agent-sandbox-benchmark/run-benchmark.sh
+++ b/agent-infra/scripts/agent-sandbox-benchmark/run-benchmark.sh
@@ -108,7 +108,7 @@ spec:
       runtimeClassName: ${runtime_class}
       containers:
       - name: agent
-        image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:v0.2.1
+        image: ghcr.io/kubernetes-sigs/agent-sandbox/agent-runtime:${AGENT_SANDBOX_VERSION:-v0.2.1}
         command: ["sleep", "${sleep_secs}"]
 YAML
   else

--- a/agent-infra/scripts/agent-sandbox-benchmark/setup.sh
+++ b/agent-infra/scripts/agent-sandbox-benchmark/setup.sh
@@ -34,7 +34,7 @@ else
 fi
 
 echo "==> Installing agent-sandbox CRDs..."
-export VERSION="${AGENT_SANDBOX_VERSION:-v0.1.0}"
+export VERSION="${AGENT_SANDBOX_VERSION:-v0.2.1}"
 kubectl apply -f "https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/manifest.yaml" || \
   echo "WARN: Could not apply manifest (offline or version mismatch). Install manually."
 

--- a/docs/inference/README.md
+++ b/docs/inference/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-03-02
+last_updated: 2026-04-06
 tags: inference, llm, vllm, serving, optimization
 canonical_path: docs/inference/README.md
 ---
@@ -55,7 +55,7 @@ Kubernetes-native platforms for orchestrating LLM inference at scale:
 | [AIBrix](https://github.com/vllm-project/aibrix) | vLLM Project | StormService + RoleSet CRDs | High-density LoRA, gateway, autoscaling, P/D disaggregation |
 | [Kthena](https://github.com/volcano-sh/kthena) | Volcano (CNCF Sandbox) | Serving Group / LWS | Gang scheduling, topology-aware, revision control |
 | [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) | NVIDIA | Grove/LWS dual mode | NVIDIA-optimized, disaggregated serving, KV routing |
-| [OME](https://github.com/sigs/ome) | Kubernetes SIG | Operator pattern | Model management, lifecycle, multi-engine support |
+| [OME](https://github.com/sgl-project/ome) | SGLang Project | Operator pattern | Model management, lifecycle, multi-engine support |
 | [KServe](https://github.com/kserve/kserve) | CNCF Incubating | InferenceService CRD | Multi-framework, canary, explainability, serverless |
 | [llm-d](https://github.com/llm-d/llm-d) | Red Hat / IBM | Dual LWS + KServe | P/D disaggregation reference implementation |
 | [vLLM production-stack](https://github.com/vllm-project/production-stack) | vLLM Project | Helm-based | Router, multi-instance, KV-aware routing |

--- a/docs/inference/aibrix.md
+++ b/docs/inference/aibrix.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2025-10-29
+last_updated: 2026-04-06
 tags: inference, aibrix, vllm, llm-serving, lora
 canonical_path: docs/inference/aibrix.md
 ---
@@ -63,17 +63,18 @@ to provide a comprehensive LLM inference platform:
 
 ## Project Status
 
-- **Current Version**: v0.4.0 (as of August 2025)
+- **Current Version**: v0.6.0 (as of March 2026)
 - **License**: Apache 2.0
 - **Maturity**: Active development with regular releases
 - **Community**: Part of vLLM project with dedicated Slack channel
 
 ## Prefill/Decode Disaggregation Support
 
-AIBrix v0.4.0 introduces comprehensive Prefill/Decode (P/D) disaggregation
+AIBrix v0.4.0 introduced comprehensive Prefill/Decode (P/D) disaggregation
 support with StormService and RoleSet CRDs to enable fine-grained
 orchestration of P/D roles, along with routing to unlock disaggregated
-inference at scale.
+inference at scale. These capabilities are now part of the current v0.6.0
+release line.
 
 Key features include:
 
@@ -94,7 +95,7 @@ For more details, see [PD Disaggregation](./pd-disaggregation.md).
 
 ```bash
 # Install component dependencies
-AIBRIX_VERSION="v0.4.0"
+AIBRIX_VERSION="v0.6.0"
 GITHUB_BASE="https://github.com/vllm-project/aibrix/releases/download"
 kubectl apply -f \
   "${GITHUB_BASE}/${AIBRIX_VERSION}/aibrix-dependency-${AIBRIX_VERSION}.yaml" \


### PR DESCRIPTION
## Summary
- sync AIBrix docs to current release line (`v0.6.0`) and update install snippet
- fix OME repository link in inference overview (`sigs/ome` -> `sgl-project/ome`)
- bump Agent Sandbox benchmark defaults from `v0.1.0` to `v0.2.1` across docs/scripts/manifests

## Validation
- searched repo for stale strings (`v0.1.0`, `v0.4.0`, `github.com/sigs/ome`) and confirmed replacements
- verified upstream release tags/assets with GitHub API before updating versions

## Notes
- kept unrelated workspace changes out of this commit
