### PR TITLE
docs: sync kubernetes sig-release v1.36 materials

### DIFF
--- a/docs/kubernetes/sig-release/v1.36/TODO-next.md
+++ b/docs/kubernetes/sig-release/v1.36/TODO-next.md
@@ -1,0 +1,48 @@
+# TODO For Next Steps (Not Executed In This PR)
+
+This file is only for planning step 2 and step 3 after step 1 research.
+
+## Step 2: English Blog Draft
+
+1. Re-check upstream status on writing day:
+- final release date confirmation
+- final release blog/theme/logo links
+- final `CHANGELOG-1.36.md` and release-notes changes
+
+2. Draft EN blog based on `research.md`:
+- executive summary
+- major GA/Beta/Alpha highlights
+- upgrade/deprecation risks
+- references
+
+3. Validate facts one more time before publish:
+- KEP stage and target release still unchanged
+- any newly disclosed known issue
+
+## Step 3: Chinese Blog Draft
+
+Status: completed in this branch.
+
+Output:
+
+- `kubernetes/sig-release/v1.36/release.md`
+
+Also added:
+
+- `AI-Infra` action-list sections in both drafts:
+- `kubernetes/sig-release/v1.36/release.en.md`
+- `kubernetes/sig-release/v1.36/release.md`
+
+1. Translate with localization (not literal conversion):
+- keep technical meaning exact
+- adapt wording to domestic/private-cloud reader focus
+
+2. Keep structure aligned with historical local posts:
+- title + theme
+- key highlights by stage
+- upgrade notes and deprecations
+- historical links and references
+
+3. Final consistency checks:
+- terminology consistency (EN/CN names)
+- KEP links and release date consistency with EN version

--- a/docs/kubernetes/sig-release/v1.36/data/enhancements-v1.36-tracked.json
+++ b/docs/kubernetes/sig-release/v1.36/data/enhancements-v1.36-tracked.json
@@ -1,0 +1,734 @@
+[
+  {
+    "number": 5882,
+    "title": "Deployment Pod Replacement Policy",
+    "url": "https://github.com/kubernetes/enhancements/issues/5882",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/apps"
+    ]
+  },
+  {
+    "number": 5866,
+    "title": "Server-side Sharded List and Watch",
+    "url": "https://github.com/kubernetes/enhancements/issues/5866",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/api-machinery"
+    ]
+  },
+  {
+    "number": 5832,
+    "title": "WAS: Decouple PodGroup API",
+    "url": "https://github.com/kubernetes/enhancements/issues/5832",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5825,
+    "title": "CRI List Streaming",
+    "url": "https://github.com/kubernetes/enhancements/issues/5825",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 5808,
+    "title": "Native Histogram Support for Kubernetes Metrics",
+    "url": "https://github.com/kubernetes/enhancements/issues/5808",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/instrumentation"
+    ]
+  },
+  {
+    "number": 5793,
+    "title": "Manifest Based Admission Control Config",
+    "url": "https://github.com/kubernetes/enhancements/issues/5793",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/api-machinery"
+    ]
+  },
+  {
+    "number": 5758,
+    "title": "Per-container ulimits configuration",
+    "url": "https://github.com/kubernetes/enhancements/issues/5758",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 5732,
+    "title": "KEP-5732: Topology-aware workload scheduling",
+    "url": "https://github.com/kubernetes/enhancements/issues/5732",
+    "stage": "stage/unknown",
+    "sigs": [
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5729,
+    "title": "DRA: ResourceClaim Support for Workloads",
+    "url": "https://github.com/kubernetes/enhancements/issues/5729",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5710,
+    "title": "Workload-aware preemption",
+    "url": "https://github.com/kubernetes/enhancements/issues/5710",
+    "stage": "stage/unknown",
+    "sigs": [
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5681,
+    "title": "Conditional Authorization",
+    "url": "https://github.com/kubernetes/enhancements/issues/5681",
+    "stage": "stage/unknown",
+    "sigs": [
+      "sig/auth"
+    ]
+  },
+  {
+    "number": 5679,
+    "title": "HPA External Metrics Fallback on Retrieval Failure",
+    "url": "https://github.com/kubernetes/enhancements/issues/5679",
+    "stage": "stage/unknown",
+    "sigs": [
+      "sig/autoscaling"
+    ]
+  },
+  {
+    "number": 5677,
+    "title": "DRA: Resource Availability Visibility",
+    "url": "https://github.com/kubernetes/enhancements/issues/5677",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/autoscaling",
+      "sig/node",
+      "sig/cli"
+    ]
+  },
+  {
+    "number": 5647,
+    "title": "Stale Controller Mitigation",
+    "url": "https://github.com/kubernetes/enhancements/issues/5647",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/api-machinery"
+    ]
+  },
+  {
+    "number": 5607,
+    "title": " Allow HostNetwork Pods to Use User Namespaces",
+    "url": "https://github.com/kubernetes/enhancements/issues/5607",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 5598,
+    "title": "Opportunistic batching",
+    "url": "https://github.com/kubernetes/enhancements/issues/5598",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5589,
+    "title": "Remove gogo protobuf dependency for Kubernetes API types",
+    "url": "https://github.com/kubernetes/enhancements/issues/5589",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/api-machinery",
+      "sig/architecture"
+    ]
+  },
+  {
+    "number": 5554,
+    "title": "Support In place update pod resources alongside static cpu manager policy",
+    "url": "https://github.com/kubernetes/enhancements/issues/5554",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 5547,
+    "title": "WAS: Integrate Workload APIs with Job controller",
+    "url": "https://github.com/kubernetes/enhancements/issues/5547",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/apps",
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5541,
+    "title": "Report last used time on a PVC",
+    "url": "https://github.com/kubernetes/enhancements/issues/5541",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/storage"
+    ]
+  },
+  {
+    "number": 5538,
+    "title": "CSI driver opt-in for service account tokens via secrets field",
+    "url": "https://github.com/kubernetes/enhancements/issues/5538",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/auth",
+      "sig/storage"
+    ]
+  },
+  {
+    "number": 5532,
+    "title": "Restart all containers on container exits",
+    "url": "https://github.com/kubernetes/enhancements/issues/5532",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 5526,
+    "title": "Pod Level Resource Managers",
+    "url": "https://github.com/kubernetes/enhancements/issues/5526",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 5517,
+    "title": "DRA: Native Resource Requests",
+    "url": "https://github.com/kubernetes/enhancements/issues/5517",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node",
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5491,
+    "title": "DRA: List Types for Attributes",
+    "url": "https://github.com/kubernetes/enhancements/issues/5491",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5440,
+    "title": "Mutable Container Resources when Job is suspended",
+    "url": "https://github.com/kubernetes/enhancements/issues/5440",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/apps"
+    ]
+  },
+  {
+    "number": 5419,
+    "title": "Pod Level Resources Support With In Place Pod Vertical Scaling",
+    "url": "https://github.com/kubernetes/enhancements/issues/5419",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 5394,
+    "title": "PSI-based node conditions",
+    "url": "https://github.com/kubernetes/enhancements/issues/5394",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 5366,
+    "title": "Graceful Leader Transition",
+    "url": "https://github.com/kubernetes/enhancements/issues/5366",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/api-machinery"
+    ]
+  },
+  {
+    "number": 5328,
+    "title": "Node Declared Features (formerly Node Capabilities)",
+    "url": "https://github.com/kubernetes/enhancements/issues/5328",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/autoscaling",
+      "sig/node",
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5311,
+    "title": "Relaxed validation for Services names",
+    "url": "https://github.com/kubernetes/enhancements/issues/5311",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/network"
+    ]
+  },
+  {
+    "number": 5304,
+    "title": "DRA: Device Attributes in Downward API",
+    "url": "https://github.com/kubernetes/enhancements/issues/5304",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 5284,
+    "title": "Constrained Impersonation",
+    "url": "https://github.com/kubernetes/enhancements/issues/5284",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/auth"
+    ]
+  },
+  {
+    "number": 5237,
+    "title": "CCM: watch-based route controller reconciliation using informers",
+    "url": "https://github.com/kubernetes/enhancements/issues/5237",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/cloud-provider"
+    ]
+  },
+  {
+    "number": 5109,
+    "title": "Split L3 Cache Topology Awareness in CPU Manager",
+    "url": "https://github.com/kubernetes/enhancements/issues/5109",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 5075,
+    "title": "DRA: Consumable Capacity",
+    "url": "https://github.com/kubernetes/enhancements/issues/5075",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/network",
+      "sig/node",
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5073,
+    "title": "Declarative Validation Of Kubernetes Native Types With validation-gen",
+    "url": "https://github.com/kubernetes/enhancements/issues/5073",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/api-machinery"
+    ]
+  },
+  {
+    "number": 5055,
+    "title": "DRA: device taints and tolerations",
+    "url": "https://github.com/kubernetes/enhancements/issues/5055",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/node",
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5040,
+    "title": "Remove gitRepo volume driver",
+    "url": "https://github.com/kubernetes/enhancements/issues/5040",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/storage"
+    ]
+  },
+  {
+    "number": 5030,
+    "title": "Integrate CSI Volume attach limits with cluster autoscaler",
+    "url": "https://github.com/kubernetes/enhancements/issues/5030",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/autoscaling",
+      "sig/scheduling",
+      "sig/storage"
+    ]
+  },
+  {
+    "number": 5018,
+    "title": "DRA: AdminAccess for ResourceClaims and ResourceClaimTemplates",
+    "url": "https://github.com/kubernetes/enhancements/issues/5018",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/auth",
+      "sig/node"
+    ]
+  },
+  {
+    "number": 5007,
+    "title": "DRA: Device Binding Conditions",
+    "url": "https://github.com/kubernetes/enhancements/issues/5007",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 5004,
+    "title": "DRA: Handle extended resource requests via DRA Driver",
+    "url": "https://github.com/kubernetes/enhancements/issues/5004",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/node",
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 4960,
+    "title": "Container Stop Signals",
+    "url": "https://github.com/kubernetes/enhancements/issues/4960",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 4876,
+    "title": "Mutable CSINode Allocatable Property",
+    "url": "https://github.com/kubernetes/enhancements/issues/4876",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/storage"
+    ]
+  },
+  {
+    "number": 4828,
+    "title": "Flagz for Kubernetes Components",
+    "url": "https://github.com/kubernetes/enhancements/issues/4828",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/instrumentation"
+    ]
+  },
+  {
+    "number": 4827,
+    "title": "Statusz for Kubernetes Components",
+    "url": "https://github.com/kubernetes/enhancements/issues/4827",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/instrumentation"
+    ]
+  },
+  {
+    "number": 4817,
+    "title": "DRA: Resource Claim Status with possible standardized network interface data",
+    "url": "https://github.com/kubernetes/enhancements/issues/4817",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/auth",
+      "sig/network",
+      "sig/node"
+    ]
+  },
+  {
+    "number": 4816,
+    "title": "DRA: Prioritized Alternatives in Device Requests",
+    "url": "https://github.com/kubernetes/enhancements/issues/4816",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/node",
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 4815,
+    "title": "DRA: Partitionable Devices",
+    "url": "https://github.com/kubernetes/enhancements/issues/4815",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/node",
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 4680,
+    "title": "Add Resource Health Status to the Pod Status for Device Plugin and DRA",
+    "url": "https://github.com/kubernetes/enhancements/issues/4680",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 4671,
+    "title": "Gang Scheduling Support in Kubernetes",
+    "url": "https://github.com/kubernetes/enhancements/issues/4671",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/scheduling"
+    ]
+  },
+  {
+    "number": 4639,
+    "title": "VolumeSource: OCI Artifact and/or Image",
+    "url": "https://github.com/kubernetes/enhancements/issues/4639",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/node",
+      "sig/storage"
+    ]
+  },
+  {
+    "number": 4563,
+    "title": "EvictionRequest API",
+    "url": "https://github.com/kubernetes/enhancements/issues/4563",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/apps",
+      "sig/node"
+    ]
+  },
+  {
+    "number": 4317,
+    "title": "Pod Certificates",
+    "url": "https://github.com/kubernetes/enhancements/issues/4317",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/auth"
+    ]
+  },
+  {
+    "number": 4265,
+    "title": "add ProcMount option",
+    "url": "https://github.com/kubernetes/enhancements/issues/4265",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/auth",
+      "sig/node"
+    ]
+  },
+  {
+    "number": 4205,
+    "title": "Support PSI based on cgroupv2",
+    "url": "https://github.com/kubernetes/enhancements/issues/4205",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 4192,
+    "title": "Move Storage Version Migrator in-tree",
+    "url": "https://github.com/kubernetes/enhancements/issues/4192",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/api-machinery"
+    ]
+  },
+  {
+    "number": 4188,
+    "title": "KEP: New kubelet gRPC API with endpoint returning local pods information",
+    "url": "https://github.com/kubernetes/enhancements/issues/4188",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node",
+      "sig/architecture"
+    ]
+  },
+  {
+    "number": 4138,
+    "title": "[KEP-3085] Add condition for sandbox creation (xposted from original issue)",
+    "url": "https://github.com/kubernetes/enhancements/issues/4138",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 4020,
+    "title": "Mixed Version Proxy (aka Unknown Version Interoperability Proxy)",
+    "url": "https://github.com/kubernetes/enhancements/issues/4020",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/api-machinery"
+    ]
+  },
+  {
+    "number": 4006,
+    "title": "Transition from SPDY to WebSockets",
+    "url": "https://github.com/kubernetes/enhancements/issues/4006",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/api-machinery",
+      "sig/cli"
+    ]
+  },
+  {
+    "number": 3962,
+    "title": "Mutating Admission Policies",
+    "url": "https://github.com/kubernetes/enhancements/issues/3962",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/api-machinery"
+    ]
+  },
+  {
+    "number": 3926,
+    "title": "Handling undecryptable resources",
+    "url": "https://github.com/kubernetes/enhancements/issues/3926",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/auth",
+      "sig/api-machinery"
+    ]
+  },
+  {
+    "number": 3695,
+    "title": "DRA: Extend PodResources to include resources from Dynamic Resource Allocation",
+    "url": "https://github.com/kubernetes/enhancements/issues/3695",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/network",
+      "sig/node"
+    ]
+  },
+  {
+    "number": 3541,
+    "title": "Add Recreate Update Strategy to StatefulSet",
+    "url": "https://github.com/kubernetes/enhancements/issues/3541",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/apps"
+    ]
+  },
+  {
+    "number": 3476,
+    "title": "VolumeGroupSnapshot",
+    "url": "https://github.com/kubernetes/enhancements/issues/3476",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/storage"
+    ]
+  },
+  {
+    "number": 3386,
+    "title": "Kubelet Evented PLEG for Better Performance",
+    "url": "https://github.com/kubernetes/enhancements/issues/3386",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 3314,
+    "title": "CSI Differential Snapshot for Block Volumes",
+    "url": "https://github.com/kubernetes/enhancements/issues/3314",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/storage"
+    ]
+  },
+  {
+    "number": 3104,
+    "title": "Separate kubectl user preferences from cluster configs",
+    "url": "https://github.com/kubernetes/enhancements/issues/3104",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/auth",
+      "sig/cli"
+    ]
+  },
+  {
+    "number": 2862,
+    "title": "Fine grained Kubelet API authorization ",
+    "url": "https://github.com/kubernetes/enhancements/issues/2862",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/auth",
+      "sig/node"
+    ]
+  },
+  {
+    "number": 2570,
+    "title": "Support memory qos with cgroups v2",
+    "url": "https://github.com/kubernetes/enhancements/issues/2570",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/node"
+    ]
+  },
+  {
+    "number": 2371,
+    "title": "cAdvisor-less, CRI-full Container and Pod Stats",
+    "url": "https://github.com/kubernetes/enhancements/issues/2371",
+    "stage": "stage/beta",
+    "sigs": [
+      "sig/node",
+      "sig/windows"
+    ]
+  },
+  {
+    "number": 2258,
+    "title": "Node log query",
+    "url": "https://github.com/kubernetes/enhancements/issues/2258",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/windows"
+    ]
+  },
+  {
+    "number": 2021,
+    "title": "Support scaling to/from zero pods for object/external metrics",
+    "url": "https://github.com/kubernetes/enhancements/issues/2021",
+    "stage": "stage/alpha",
+    "sigs": [
+      "sig/autoscaling"
+    ]
+  },
+  {
+    "number": 1710,
+    "title": "Speed up recursive SELinux label change",
+    "url": "https://github.com/kubernetes/enhancements/issues/1710",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/node",
+      "sig/storage"
+    ]
+  },
+  {
+    "number": 740,
+    "title": "API for external signing of Service Account tokens",
+    "url": "https://github.com/kubernetes/enhancements/issues/740",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/auth"
+    ]
+  },
+  {
+    "number": 127,
+    "title": "Support User Namespaces in pods",
+    "url": "https://github.com/kubernetes/enhancements/issues/127",
+    "stage": "stage/stable",
+    "sigs": [
+      "sig/node"
+    ]
+  }
+]

--- a/docs/kubernetes/sig-release/v1.36/data/sig-release-discussion-2958-comments.json
+++ b/docs/kubernetes/sig-release/v1.36/data/sig-release-discussion-2958-comments.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "repository": {
+      "discussion": {
+        "comments": {
+          "totalCount": 2,
+          "nodes": [
+            {
+              "author": {
+                "login": "danwinship"
+              },
+              "createdAt": "2026-02-25T14:49:17Z",
+              "body": "[KEP-4858](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/4858-ip-cidr-validation/README.md) \"IP/CIDR Validation Improvements\" is now Beta, meaning that non-canonical IP address formats (like \"`010.000.001.005`\" or \"`::ffff:10.0.1.5`\") and ambiguous CIDR values (like \"`192.168.1.5/24`\" in a context that's expecting either \"`192.168.1.0/24`\" or \"`192.168.1.5/32`\") are no longer considered valid in core Kubernetes objects, and attempts to set fields to such values will fail. This change was made because these types of values might be interpreted differently by different implementations, potentially allowing for security exploits (as in CVE-2021-29923).\r\n\r\nWhile this is technically a breaking change, there's not really any good reason anybody should have been setting fields to such values before, and we've been emitting warnings about them for a few releases now, so hopefully this change should have no effect on anyone, other than guaranteeing better security and interoperability in the future.",
+              "url": "https://github.com/kubernetes/sig-release/discussions/2958#discussioncomment-15924135"
+            },
+            {
+              "author": {
+                "login": "xing-yang"
+              },
+              "createdAt": "2026-03-04T02:45:04Z",
+              "body": "From SIG-Storage:\r\nNew Features:\r\n\r\n- [Volume Group Snapshot](https://github.com/kubernetes/enhancements/issues/3476) feature targets GA in Kubernetes 1.36 release. The support for volume group snapshots relies on a set of [extension APIs for group snapshots](https://kubernetes-csi.github.io/docs/group-snapshot-restore-feature.html#volume-group-snapshot-apis). These APIs allow users to take crash consistent snapshots for a set of volumes. A key aim is to allow you to restore that set of snapshots to new volumes and recover your workload based on a crash consistent recovery point.\r\n- [Service Account Tokens via Secrets Field](https://github.com/kubernetes/enhancements/issues/5538) feature targets GA in v1.36. This feature adds an optional ability for CSI drivers to receive service account tokens via secrets field instead of volume context.\r\n[Mutable Volume Attach Limits](https://github.com/kubernetes/enhancements/issues/4876) feature targets GA in v1.36. This feature allows CSI drivers to dynamically adjust the maximum number of attachable volumes at runtime.\r\n- [SELinux Relabeling with Mount Options](https://github.com/kubernetes/enhancements/issues/1710) for non-RWOP volumes.\r\n  - Speeds up container startup by mounting volumes with the correct SELinux label\r\n  - Selinux changepolicy feature gate targets GA in 1.36\r\n\r\nDriver disabled:\r\n- Starting Kubernetes v1.36 the [`gitRepo` volume plugin](https://github.com/kubernetes/enhancements/issues/5040) has been disabled and cannot be enabled.\r\n\r\ncc @saad-ali @msau42 @jsafrane ",
+              "url": "https://github.com/kubernetes/sig-release/discussions/2958#discussioncomment-15992196"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/docs/kubernetes/sig-release/v1.36/data/sig-release-discussion-2958.json
+++ b/docs/kubernetes/sig-release/v1.36/data/sig-release-discussion-2958.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "repository": {
+      "discussion": {
+        "number": 2958,
+        "title": "Kubernetes v1.36 Release Highlights",
+        "url": "https://github.com/kubernetes/sig-release/discussions/2958",
+        "body": "This is a discussion to collect the Release Highlights for the v1.36 release cycle.\r\n\r\nRelease Highlights are an essential part of the Kubernetes release cycle, providing a bird's-eye view of improvements, breaking changes, and user-facing changes coming in the upcoming release. The release Comms team is asking SIGs to comment on this discussion and highlight items we should include in release communications for v1.36.\r\n\r\n> [!IMPORTANT]\r\n> For each submission, please include a link to the KEP, the stage the feature is moving to, and a brief description of the KEP that will be used as an outline for the blog post content.\r\n> \r\n> The deadline for v1.36 Release Highlights is **Tuesday 31st March 2026**.\r\n\r\nSome references for the previous releases:\r\n- https://github.com/kubernetes/sig-release/discussions/2903\r\n- https://github.com/kubernetes/sig-release/discussions/2806\r\n\r\ncc @kubernetes/release-team-leads\r\ncc @chanieljdan @kirti763 @SophiaUgo @SwathiR03 @UtkarshUmre\r\n",
+        "createdAt": "2026-02-11T13:18:47Z"
+      }
+    }
+  }
+}

--- a/docs/kubernetes/sig-release/v1.36/prerelease.md
+++ b/docs/kubernetes/sig-release/v1.36/prerelease.md
@@ -1,0 +1,92 @@
+# Kubernetes v1.36 前瞻：弃用移除与重点增强
+
+作者：Chad Crowell、Kirti Goyal、Sophia Ugochukwu、Swathi Rao、Utkarsh Umre（2026 年 3 月 30 日）
+
+Kubernetes v1.36 预计将在 2026 年 4 月下旬发布。本文基于当前开发状态梳理关键变化，正式发布前仍可能调整。
+
+## Kubernetes API 的弃用与移除流程
+
+Kubernetes 有明确的 API 弃用策略：
+
+- 稳定版 API 只有在有新的稳定替代版本时才会被弃用。
+- 被弃用后会保留一段周期并给出告警。
+- 移除后需迁移到替代方案。
+- 不同稳定级别（GA/Beta/Alpha）对应不同最短保留期。
+
+所有移除都会遵循该策略，并在弃用指南中提供迁移路径。
+
+## Ingress NGINX 退役
+
+为优先保障生态安全，SIG Network 与 SRC 已于 2026 年 3 月 24 日退役 Ingress NGINX。之后不再发布新版本、修复或安全更新。现有部署可继续运行，安装制品（如 Helm chart、镜像）仍可获取。
+
+参考：
+
+- [Ingress NGINX 退役：你需要了解的内容](https://kubernetes.io/zh-cn/blog/2025/11/11/ingress-nginx-retirement/)
+
+## v1.36 的弃用与移除
+
+### 1) `Service.spec.externalIPs`
+
+- v1.36 开始弃用并出现告警。
+- 计划在 v1.43 完全移除。
+- 该字段长期存在安全风险（如 CVE-2020-8554）。
+- 建议改用 `LoadBalancer`、`NodePort` 或 `Gateway API`。
+
+参考：
+
+- [KEP-5707：Deprecate service.spec.externalIPs](https://kep.k8s.io/5707)
+
+### 2) `gitRepo` 卷驱动
+
+- 该能力自 v1.11 起已弃用。
+- v1.36 起永久禁用且无法重新启用。
+- 依赖该能力的工作负载需迁移到 `initContainer` 或外部 `git-sync` 等方案。
+
+参考：
+
+- [KEP-5040：Remove gitRepo volume driver](https://kep.k8s.io/5040)
+
+## v1.36 重点增强
+
+### 1) SELinux 卷标记提速（GA）
+
+通过挂载时设置上下文替代递归重标记，提升一致性并减少 Pod 启动延迟。
+
+- [KEP-1710：SELinux relabeling with mount options](https://kep.k8s.io/1710)
+
+### 2) ServiceAccount Token 外部签名（GA）
+
+kube-apiserver 可将签名委托给外部 KMS/HSM，提升安全性并简化集中式密钥管理。
+
+- [KEP-740：External ServiceAccount token signing](https://kep.k8s.io/740)
+
+### 3) DRA 设备污点与容忍（Beta）
+
+允许 DRA 驱动或管理员按规则给设备打污点，避免未显式容忍的工作负载误用特定硬件。
+
+- [KEP-5055：DRA device taints and tolerations](https://kep.k8s.io/5055)
+
+### 4) DRA 可分区设备
+
+支持把单个加速器划分为多个逻辑单元共享使用，提高 GPU 等高成本资源利用率。
+
+- [KEP-4815：DRA partitionable devices](https://kep.k8s.io/4815)
+
+## 更多信息
+
+v1.36 的正式变更将以该版本的 CHANGELOG 与 release notes 为准。当前计划发布时间为 2026 年 4 月 22 日（周三）。
+
+- [Kubernetes v1.36 Sneak Peek](https://kubernetes.io/blog/2026/03/30/kubernetes-v1-36-sneak-peek/)
+- [v1.36 Release Highlights #2958](https://github.com/kubernetes/sig-release/discussions/2958)
+
+## 如何参与 Kubernetes 社区
+
+- 关注 Bluesky：`@kubernetes.io`
+- 参与 [Discuss 社区讨论](https://discuss.kubernetes.io/)
+- 加入 [Kubernetes Slack 社区](https://slack.k8s.io/)
+- 在 [Server Fault](https://serverfault.com/questions/tagged/kubernetes) 或 [Stack Overflow](https://stackoverflow.com/questions/tagged/kubernetes) 参与问答
+- 在 [Kubernetes 博客](https://kubernetes.io/blog/) 了解更多动态
+
+## 来源
+
+- <https://kubernetes.io/blog/2026/03/30/kubernetes-v1-36-sneak-peek/>

--- a/docs/kubernetes/sig-release/v1.36/release.en.md
+++ b/docs/kubernetes/sig-release/v1.36/release.en.md
@@ -1,0 +1,230 @@
+# Kubernetes v1.36 English Draft (Writing-Day Recheck: 2026-03-19)
+
+This draft is refreshed with upstream status rechecked on **March 19, 2026 (UTC+8)**.
+
+## Writing-Day Upstream Status Recheck
+
+### 1) Final release date confirmation
+
+Current official release-cycle source still shows:
+
+- planned v1.36 GA release date: **Wednesday, April 22, 2026**
+- source: `kubernetes/sig-release` release-1.36 README
+- upstream file revision checked: `sha e674160cb986b4244d1fdcafe6d499ee536626bf`
+
+Reference: <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/README.md>
+
+### 2) Final release blog / theme / logo links
+
+As of this recheck:
+
+- no final v1.36 release blog post is published in `kubernetes/website` blog post folder for 2026
+- no final v1.36 logo assets are published in `kubernetes/sig-release/releases/release-1.36/logo` (only `.gitkeep`)
+- there is still an open WIP mid-cycle/release PR: <https://github.com/kubernetes/website/pull/54866>
+
+Therefore, final official blog/theme/logo links are **not available yet**.
+
+### 3) Final CHANGELOG-1.36.md and release-notes changes
+
+### CHANGELOG-1.36.md (upstream status)
+
+Current changelog still contains pre-GA entries:
+
+- `v1.36.0-alpha.1`
+- `v1.36.0-alpha.2`
+- no final `v1.36.0` GA section yet
+- upstream file revision checked: `sha 37cd7afb115a346467ab778cd9a3104140c65c7a`
+
+Reference: <https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md>
+
+### release-notes-draft.md (upstream status)
+
+Current draft still has expected pre-GA structure:
+
+- `Urgent Upgrade Notes`
+- `Deprecation`
+- `API Change`
+- `Feature`
+- `Bug or Regression`
+- upstream file revision checked: `sha d8abece0a18ba0c65eda46bea130b499cc9fe3b1`
+
+Reference: <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-notes/release-notes-draft.md>
+
+## Executive Summary
+
+Kubernetes v1.36 is in late-cycle pre-GA state. The strongest current signal is not a finalized marketing narrative yet, but the technical direction:
+
+1. policy and API machinery maturity continues (notably `MutatingAdmissionPolicy` and protobuf cleanup)
+2. storage/DRA capabilities keep moving toward production use
+3. node/scheduler changes require plugin and controller compatibility validation before upgrade
+4. deprecation/removal items (`gitRepo` plugin, flex-volume integration path in kubeadm) need explicit operator attention
+
+## Major Highlights By Stage
+
+### GA / Stable Highlights (verified)
+
+- [KEP-3962 Mutating Admission Policies](https://github.com/kubernetes/enhancements/issues/3962)
+- [KEP-5589 Remove gogo protobuf dependency for Kubernetes API types](https://github.com/kubernetes/enhancements/issues/5589)
+- [KEP-3476 VolumeGroupSnapshot](https://github.com/kubernetes/enhancements/issues/3476)
+- [KEP-4876 Mutable CSINode Allocatable Property](https://github.com/kubernetes/enhancements/issues/4876)
+- [KEP-5538 CSI driver SA token via secrets field](https://github.com/kubernetes/enhancements/issues/5538)
+- [KEP-2258 Node log query](https://github.com/kubernetes/enhancements/issues/2258)
+- [KEP-127 User Namespaces in pods](https://github.com/kubernetes/enhancements/issues/127)
+
+### Beta Highlights (verified)
+
+- [KEP-4006 Transition from SPDY to WebSockets](https://github.com/kubernetes/enhancements/issues/4006)
+- [KEP-5311 Relaxed validation for Services names](https://github.com/kubernetes/enhancements/issues/5311)
+- [KEP-5284 Constrained Impersonation](https://github.com/kubernetes/enhancements/issues/5284)
+- [KEP-4680 Resource Health Status](https://github.com/kubernetes/enhancements/issues/4680)
+- [KEP-4858 IP/CIDR validation improvements](https://github.com/kubernetes/enhancements/issues/4858): currently `stage/beta`, but does **not** currently show milestone `v1.36` on its issue metadata
+
+### Alpha Highlights (verified)
+
+- [KEP-5866 Server-side Sharded List and Watch](https://github.com/kubernetes/enhancements/issues/5866)
+- [KEP-5882 Deployment Pod Replacement Policy](https://github.com/kubernetes/enhancements/issues/5882)
+- [KEP-5729 DRA: ResourceClaim Support for Workloads](https://github.com/kubernetes/enhancements/issues/5729)
+
+## Highlights Reported In `kubernetes/sig-release#2958`
+
+`kubernetes/sig-release` discussion [#2958](https://github.com/kubernetes/sig-release/discussions/2958) contains cross-SIG release highlights. The features below were explicitly called out there and rechecked against current enhancement metadata on **March 23, 2026 (UTC+8)**.
+
+### KEP-4858: IP/CIDR Validation Improvements (Beta)
+
+This change tightens validation so non-canonical IP/CIDR forms are rejected more consistently, reducing ambiguity between API input, controller logic, and network policy behavior. For operators, the main impact is configuration hygiene: legacy or loosely formatted addresses that previously slipped through can become upgrade blockers once stricter validation gates are enforced.
+
+### KEP-3476: VolumeGroupSnapshot (GA target in v1.36)
+
+Volume group snapshots extend snapshot semantics from single PVCs to related volume sets, which matters for applications that must preserve write-order consistency across multiple disks. This is particularly useful for coordinated backup/recovery workflows where training checkpoints, metadata, and model state must be captured as one logical unit.
+
+### KEP-5538: Service Account Tokens For CSI Via `secrets` Field (GA target in v1.36)
+
+This feature standardizes how CSI drivers receive scoped service account tokens through the `secrets` field path, reducing ad hoc credential wiring and helping operators align with short-lived token best practices. In production, it simplifies credential rotation and strengthens least-privilege boundaries between storage plugins and workloads.
+
+### KEP-4876: Mutable `CSINode` Allocatable (GA target in v1.36)
+
+Allowing mutable allocatable values in `CSINode` lets storage capacity signals track runtime reality instead of static startup assumptions. The practical outcome is better scheduling decisions for attach-limited environments and fewer false placements caused by stale volume-attachment limits.
+
+### KEP-1710: SELinux Relabeling With Mount Options For Non-RWOP Volumes (GA target in v1.36)
+
+This work improves SELinux labeling behavior for non-RWOP volume scenarios by using mount-option-based handling, lowering relabel overhead and reducing contention for shared-volume use cases. Clusters with strict SELinux enforcement can get more predictable startup behavior while keeping confinement guarantees intact.
+
+### KEP-5040: `gitRepo` Volume Plugin Disabled In v1.36
+
+`gitRepo` has long-standing security and maintenance concerns, and v1.36 continues the removal path by disabling it. Teams that still rely on `gitRepo` must migrate to safer patterns such as init containers, CSI-backed content distribution, or build-time artifact packaging before production rollout.
+
+### KEP-3104: `kubectl` User Preferences (`kuberc`) (Beta target in v1.36)
+
+The `kuberc` effort separates user preferences from cluster connection data and expands CLI behavior customization, including credential-plugin-related workflows. This improves UX consistency for platform teams that manage many contexts and helps make local `kubectl` behavior more explicit and reviewable.
+
+### KEP-5547: Workload APIs For Job Controller (Alpha target in v1.36)
+
+This alpha introduces workload-oriented API direction around Job execution, aiming to better express workload intent and improve controller integration patterns. For early adopters, it is primarily an experimentation track to validate API shape and controller semantics rather than an immediate production default.
+
+### KEP-5440: Mutable Container Resources In Suspended Jobs (Beta target in v1.36)
+
+Promoting this capability to beta allows resource requests/limits adjustments while Jobs are suspended, enabling safer queue-time tuning before execution begins. It is useful in batch/AI pipelines where capacity planning often changes between submission and actual start time.
+
+### Scalability Signal: Tested Resource Size Raised From 800MB To 1.5GB
+
+SIG Scalability also called out the increase in tested resource size envelope (from 800MB to 1.5GB) under ongoing scalability work. While not itself a user-facing API feature, it signals stronger confidence in control-plane handling of larger object payload scenarios and helps frame risk for large-cluster operators.
+
+### Additional Reply Highlights (March 24, 2026 update)
+
+Discussion replies added additional highlights beyond the original top-level comments:
+
+#### KEP-5707: Deprecate `Service.spec.externalIPs` (deprecation process starts in v1.36)
+
+SIG Network called out that v1.36 starts the deprecation path for `Service.spec.externalIPs` by introducing warnings on usage. This is an early but important operator signal: teams should begin inventory and migration planning now to avoid being forced into late-cycle changes once stronger restrictions arrive in later releases.
+
+#### KEP-3157: Watch List / Streaming Initial List (highlighted by SIG API Machinery)
+
+This capability allows informer initialization to obtain initial state through a streaming watch path rather than LIST chunking, which reduces API server memory pressure and improves large-cluster bootstrap behavior. For platform teams, the main value is lower read amplification during controller startup and relist-heavy periods.
+
+#### KEP-4988: Snapshottable API Server Cache (highlighted by SIG API Machinery)
+
+This work enables point-in-time snapshots from the watch cache so paginated LIST requests can be served from cache more often instead of falling back to etcd. Combined with recent cache-read improvements, it supports a multi-release API read-path optimization direction for better scalability and latency stability.
+
+#### KEP-5073: Declarative Validation of Native Types (highlighted by SIG API Machinery)
+
+This feature applies CEL-based declarative validation to built-in Kubernetes types through `validation-gen`, reducing the maintenance burden of handwritten validation logic in Go. The practical impact is improved consistency and reviewability of validation rules across native APIs.
+
+#### KEP-5793: Manifest-Based Admission Control Config (Alpha in v1.36)
+
+This alpha introduces startup-time manifest configuration for admission webhooks/policies in kube-apiserver, ensuring selected policies are active before request handling begins. It is especially relevant for platform security baselines where bootstrap enforcement guarantees matter.
+
+## Upgrade / Deprecation Risk Notes
+
+From current changelog and release-notes draft signals, prioritize these upgrade checks:
+
+1. Scheduler plugin compatibility: interface/behavior updates around `PreBind` and `PostFilter`-related mechanics require retesting for custom scheduler plugins.
+2. kubeadm + flex-volume path changes: integrated flex-volume support behavior in kubeadm has changed; clusters still relying on legacy paths need migration/custom handling.
+3. `gitRepo` volume plugin direction: current release-note direction indicates disabled-by-default behavior without re-enable path.
+4. API/client-go behavior shifts: informer and API machinery correctness/performance changes may surface hidden assumptions in custom controllers/operators.
+
+## AI-Infra Action List
+
+For AI platform / AI-Infra teams (GPU and mixed training/inference workloads), use this execution checklist:
+
+1. Runtime baseline audit: verify `containerd`, `runc/crun`, and cgroup mode by node pool.
+2. Scheduler canary validation: test custom scheduling behavior against v1.36 changes with representative AI workloads.
+3. DRA readiness review: confirm CRDs/controllers/device plugins are aligned with current DRA direction.
+4. Storage recovery drill: validate snapshot/restore workflows for model-serving and training-state volumes.
+5. Admission policy migration review: identify mutating webhook rules that can migrate to `MutatingAdmissionPolicy`.
+6. Controller regression sweep: run tests for client-go informer and API behavior assumptions.
+7. Network data hygiene: clean non-canonical IP/CIDR entries before stricter validation bites.
+8. Progressive rollout gates: enforce staged rollout with explicit rollback and AI SLO checks.
+
+## Final Validation Before Publish
+
+### KEP stage and target release still unchanged?
+
+Rechecked on writing day for referenced KEPs:
+
+- `3962`: `stage/stable`, milestone `v1.36`
+- `5589`: `stage/stable`, milestone `v1.36`
+- `3476`: `stage/stable`, milestone `v1.36`
+- `4876`: `stage/stable`, milestone `v1.36`
+- `5538`: `stage/stable`, milestone `v1.36`
+- `2258`: `stage/stable`, milestone `v1.36`
+- `127`: `stage/stable`, milestone `v1.36`
+- `4858`: `stage/beta`, milestone `null`
+- `4006`: `stage/beta`, milestone `v1.36`
+- `5311`: `stage/beta`, milestone `v1.36`
+- `5284`: `stage/beta`, milestone `v1.36`
+- `4680`: `stage/beta`, milestone `v1.36`
+- `5866`: `stage/alpha`, milestone `v1.36`
+- `5882`: `stage/alpha`, milestone `v1.36`
+- `5729`: `stage/alpha`, milestone `v1.36`
+- `1710`: `stage/stable`, milestone `v1.36`
+- `5040`: `stage/beta`, milestone `v1.36`
+- `3104`: `stage/beta`, milestone `v1.36`
+- `5547`: `stage/alpha`, milestone `v1.36`
+- `5440`: `stage/beta`, milestone `v1.36`
+- `5707`: `stage/none`, milestone `null`
+- `3157`: `stage/beta`, milestone `null`
+- `4988`: `stage/beta`, milestone `null`
+- `5073`: `stage/beta`, milestone `v1.36`
+- `5793`: `stage/alpha`, milestone `v1.36`
+
+Note: the March 24, 2026 reply in discussion `#2958` frames `3157`, `4988`, and `5073` as stable-graduation highlights, but current enhancement issue labels still show `stage/beta` for these three items.
+
+### Any newly disclosed known issue?
+
+Writing-day queries found **no** v1.36 known-issue ticket in `kubernetes/kubernetes` for:
+
+- title search: `"known issue"` + `1.36`
+- label/milestone search: `label:kind/known-issue milestone:v1.36`
+
+This should still be rechecked again right before final publication.
+
+## References
+
+- <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/README.md>
+- <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-team.md>
+- <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/links.md>
+- <https://github.com/kubernetes/kubernetes/milestone/69>
+- <https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md>
+- <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-notes/release-notes-draft.md>
+- <https://github.com/kubernetes/sig-release/discussions/2958>
+- <https://github.com/kubernetes/website/pull/54866>

--- a/docs/kubernetes/sig-release/v1.36/release.md
+++ b/docs/kubernetes/sig-release/v1.36/release.md
@@ -1,0 +1,121 @@
+# Kubernetes v1.36 正式发布稿（精简版草案）
+
+> 写作基线：截至 2026-03-31 的上游公开信息与 `kubernetes/sig-release#2958` 讨论内容。v1.36 计划发布时间为 2026-04-22（周三），正式发布当天请以 CHANGELOG 和 release notes 为准。
+
+本文结构按“前瞻精简 + highlights 展开”组织：
+- 前瞻里已经提到的内容，在这里做升级必读级别的精简提示。
+- `#2958` 讨论中的重点功能作为正文主线，提供相对完整说明。
+
+## 一、升级必读（来自 prerelease，精简版）
+
+### 1) 弃用与移除
+
+- `Service.spec.externalIPs`：v1.36 开始弃用并给出告警，计划 v1.43 移除。建议迁移到 `LoadBalancer`、`NodePort` 或 `Gateway API`。（KEP-5707）
+- `gitRepo` 卷驱动：v1.36 起永久禁用且不可重新启用。建议改为 `initContainer`、镜像构建阶段打包或外部 `git-sync`。（KEP-5040）
+
+### 2) 生态风险提示
+
+- Ingress NGINX 已在 2026 年 3 月退役，不再提供后续修复和安全更新。现网可继续运行，但建议尽快完成迁移方案评估。
+
+## 二、Highlights Discussion 重点功能（展开版）
+
+### 重点一：Mutating Admission Policies 升级到 GA（KEP-3962）
+
+过去很多团队依赖 mutating webhook 做策略注入、默认值补全和安全控制，但 webhook 体系本身有明显运维成本：需要额外部署与证书管理、故障会放大 API 请求路径风险、升级和排障链路也更长。对于多集群平台，这类“外置准入逻辑”通常是稳定性薄弱点之一。
+
+v1.36 中，基于 CEL 的 Mutating Admission Policies 进入 GA，意味着“声明式、进程内”的变更准入能力进入稳定阶段。它与已 GA 的 Validating Admission Policy 形成闭环，让集群在“校验 + 变更”两个环节都能减少对外部 webhook 的硬依赖。对平台团队来说，最直接价值是把一部分高频、可声明化的准入逻辑收敛到 apiserver 内部能力，降低控制面外围组件复杂度。
+
+落地上建议采用分层迁移：先从无副作用、纯字段变换的 webhook 规则迁入 CEL；再评估是否继续保留少量复杂 webhook（例如强依赖外部系统查询或复杂状态编排的场景）。这样可以在不牺牲策略能力的前提下，逐步换取更可控的稳定性与变更成本。
+
+### 重点二：ServiceAccount Token 外部签名升级到 GA（KEP-740）
+
+传统模式下，kube-apiserver 直接持有 ServiceAccount token 签名密钥，密钥生命周期与控制面节点绑定较深。对有合规要求或集中密钥管理要求的组织，这会带来审计、轮换、权限隔离上的治理压力。
+
+KEP-740 在 v1.36 的稳定化价值，在于把签名能力标准化地委托给外部系统（如 HSM、云 KMS），让 Kubernetes 与企业既有密钥治理体系对齐。它并不只是“换个签名位置”，而是把密钥保护边界、轮换流程和审计责任从单集群节点层面提升到统一安全基础设施层面。
+
+实施时建议重点关注三件事：第一，签名链路延迟和可用性对认证路径的影响；第二，外部签名服务故障时的降级和恢复流程；第三，密钥轮换演练与审计证据闭环。做完这三项验证，外部签名才能真正转化为生产收益而不仅是架构升级。
+
+### 重点三：Volume Group Snapshot 面向 GA（KEP-3476）
+
+单卷快照难以覆盖多卷应用的一致性恢复诉求：当数据库数据卷、日志卷、元数据卷之间存在写入顺序关系时，分别快照往往无法保证同一恢复点。对训练平台、状态型中间件和复杂事务应用，这个问题在故障恢复时尤为明显。
+
+Volume Group Snapshot 的核心价值，是把“多个相关卷”作为一个逻辑组进行快照与恢复，目标是提供 crash-consistent 的恢复点。它依赖 CSI 侧的一组扩展 API，能力边界清晰，也更利于存储厂商和平台团队在统一接口下协作。
+
+从平台实践看，这项能力最适合进入“备份恢复演练”而不仅是功能开关验证：建议把它纳入 RTO/RPO 目标校验，针对典型多卷工作负载做周期性恢复演练。只有把恢复链路跑通并量化结果，才能真正发挥该特性的业务价值。
+
+## 三、其他 Highlights（每项一段）
+
+### 1) 细粒度 Kubelet API 鉴权（KEP-2862，Stable）
+
+该能力允许按请求类型（如 exec、logs、metrics、port-forward）进行更细粒度授权，而不是把 kubelet 端点访问作为粗粒度权限整体放开。它的实际意义是让节点侧接口更接近最小权限模型，降低“拿到一种权限即可过度访问”的风险。
+
+### 2) DRA AdminAccess for ResourceClaims（KEP-5018，Stable）
+
+该特性支持以特权模式创建 ResourceClaim，用于在设备已被占用时执行管理类任务（如健康检查、状态查看）。对共享加速器环境而言，这有助于把“运维可见性”与“业务占用路径”解耦，减少排障时对业务负载的干扰。
+
+### 3) Constrained Impersonation（KEP-5284，Beta）
+
+它允许发起模拟（impersonation）的一方主动将自身可用权限进一步收敛到子集，避免直接获得目标身份的完整权限视图。对多租户平台和审计敏感场景，这让模拟机制更适合纳入日常运维而非仅限特权操作。
+
+### 4) IP/CIDR Validation Improvements（KEP-4858，Beta）
+
+该改动收紧了非规范和歧义 IP/CIDR 写法的接受范围，减少不同实现间解释不一致引发的安全与互通问题。升级前建议先做配置巡检，清理历史遗留的“可解析但不规范”地址写法，避免在发布窗口触发阻塞。
+
+### 5) statusz / flagz（KEP-4827、KEP-4828，Beta）
+
+核心组件的 `/statusz` 与 `/flagz` 能力升级到 beta 且默认启用，使组件运行状态和关键配置暴露方式更一致。对平台可观测体系来说，这提升了控制面日常巡检和基线核对效率。
+
+### 6) Mixed Version Proxy（KEP-4020，Beta）
+
+该能力在版本偏斜场景下把请求转发到可处理该资源的 API Server，并提供更完整的聚合发现视图。它对“滚动升级中偶发 404/发现不一致”的缓解价值较高，适合作为升级窗口稳定性增强项来评估。
+
+### 7) HPA Scale to Zero（KEP-2021，Alpha）
+
+HPA 在 object/external metrics 场景支持从 0 到非 0 的伸缩能力，为事件驱动和低频工作负载提供更激进的成本优化空间。由于仍处于 Alpha，建议仅在边界可控场景试点，并明确冷启动与指标时效的观测基线。
+
+### 8) Workload Aware Scheduling（WAS）相关方向（SIG Scheduling）
+
+SIG Scheduling 在 #2958 中将 WAS 作为当前重点方向，关联 KEP 包括 5832、5732、5729、5710、5547、4671。该方向的核心目标是让调度器更理解“工作负载级”约束（如 PodGroup、拓扑与抢占协同），对 AI/批处理集群的价值尤其明显。
+
+### 9) Declarative Validation（KEP-5073，GA 方向）
+
+除 Mutating Admission Policy 外，Declarative Validation 的 GA 方向也值得作为 v1.36 重点叙事：它把“声明式校验”能力推进到更稳定阶段，帮助平台将部分分散在 webhook 或自定义控制器中的校验逻辑收敛到统一的 API 语义层。
+
+### 10) DRA 1.36 打包更新（稳定化 + 新能力并行）
+
+DRA 在 v1.36 的信号不是单点特性，而是多项能力并行推进：包括 prioritized list、extended resource、partitionable devices、device taints、binding conditions，以及 workload / native resource / visibility 等方向。对 AI 和异构算力平台，更建议将其作为一组“资源编排能力跃迁”来评估。
+
+### 11) User Namespaces（GA）落地实践
+
+User Namespaces 进入 GA 后，容器内用户与宿主机用户隔离的工程可用性更强，适合在多租户场景中与 RuntimeClass、seccomp、SELinux/AppArmor 等机制配套落地，形成“默认最小权限 + 分层隔离”的节点安全基线。
+
+### 12) 控制面可扩展性改进（KEP-5647、KEP-5866）
+
+controller staleness mitigation 与 server-side sharded list/watch 组合起来，分别针对控制器端陈旧状态影响与 apiserver 大规模 list/watch 压力做优化。两者的共同价值是把“控制面在大集群下的稳定性”从经验调优转向可机制化改进。
+
+### 13) SELinux 兼容准备（升级风险前置）
+
+虽然相关 breaking changes 主题常被放在后续版本窗口讨论，但其核心动作需要在 v1.36 周期前置完成：尽早盘点现有工作负载的 SELinux 相关假设与策略依赖，避免升级窗口内集中暴露兼容性问题。
+
+> 说明：EvictionRequest API、HPA fallback external metrics、Deployment Pod Replacement Policy 相关稿件当前仍以占位探索为主，暂不作为本版 release 主线展开。
+
+## 四、建议的升级动作
+
+1. 全量扫描清单与集群对象，完成 `externalIPs`、`gitRepo` 使用点盘点和迁移计划。
+2. 对入口层做维护状态审计，尽快推进 Ingress NGINX 迁移路线。
+3. 以 staging 为主验证准入策略、API Machinery 与调度相关改动，再逐步推进生产。
+4. 对多卷状态型业务执行组快照恢复演练，量化 RTO/RPO 并形成发布闸门。
+5. 升级当天对照最终 `CHANGELOG-1.36.md` 与 release notes 做差异复核。
+
+## 五、参考链接
+
+- <https://kubernetes.io/blog/2026/03/30/kubernetes-v1-36-sneak-peek/>
+- <https://github.com/kubernetes/sig-release/discussions/2958>
+- <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/README.md>
+- <https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md>
+- <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-notes/release-notes-draft.md>
+- <https://kep.k8s.io/5707>
+- <https://kep.k8s.io/5040>
+- <https://kep.k8s.io/3962>
+- <https://kep.k8s.io/740>
+- <https://kep.k8s.io/3476>

--- a/docs/kubernetes/sig-release/v1.36/research.md
+++ b/docs/kubernetes/sig-release/v1.36/research.md
@@ -1,0 +1,230 @@
+# Kubernetes v1.36 Release Blog Research (Issue #34)
+
+- Issue: https://github.com/DaoCloud-OpenSource/docs/issues/34
+- Scope of this delivery: step 1 only (collect and organize information, no EN/ZH blog draft yet)
+- Snapshot time (UTC+8): 2026-03-18
+
+## 1) Issue Context
+
+Issue #34 currently contains only:
+
+- Title: `Kubernetes v1.36  release blog`
+- Body: `following previous blogs`
+
+So this research pack is built as the input foundation for later writing.
+
+## 2) Existing Local Templates and Style in This Repo
+
+Relevant local references:
+
+- `kubernetes/sig-release/how-to-write-release-blog.md`
+- `kubernetes/sig-release/v1.35/release.md`
+- `kubernetes/sig-release/v1.34/release.md`
+- `kubernetes/sig-release/v1.33/release.md`
+
+Observed structure pattern (recent versions):
+
+1. headline + release date + theme
+2. release logo/theme interpretation
+3. install/upgrade notes
+4. GA/stable highlights
+5. beta highlights
+6. alpha highlights
+7. deprecations/removals
+8. DaoCloud/community contributions
+9. references + historical links
+
+## 3) Official v1.36 Timeline (Upstream)
+
+Source:
+
+- https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/README.md
+
+Key dates:
+
+- Release cycle start: 2026-01-12
+- Production Readiness Freeze: 2026-02-04 (AoE) / 2026-02-05 12:00 UTC
+- Enhancements Freeze: 2026-02-11 (AoE) / 2026-02-12 12:00 UTC
+- Feature blog freeze: 2026-02-26 (AoE) / 2026-02-27 12:00 UTC
+- Code Freeze + Test Freeze: 2026-03-18 (AoE) / 2026-03-19 12:00 UTC
+- Docs Freeze: 2026-04-08 (AoE) / 2026-04-09 12:00 UTC
+- Planned GA release (`v1.36.0`): 2026-04-22
+
+Current point-in-time (this research snapshot): code/test freeze day.
+
+## 4) Official People and Tracking Boards
+
+Release team and tracking links:
+
+- Release team: https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-team.md
+- Links index: https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/links.md
+- Enhancements board: https://github.com/orgs/kubernetes/projects/241/views/1
+- Bug triage board: https://github.com/orgs/kubernetes/projects/80/views/29
+- CI signal board: https://github.com/orgs/kubernetes/projects/68/views/41
+- Kubernetes milestone v1.36: https://github.com/kubernetes/kubernetes/milestone/69
+
+Milestone snapshot (`kubernetes/kubernetes` milestone #69):
+
+- open issues: 20
+- closed issues: 955
+- state: open
+- updated_at: 2026-03-18T08:56:41Z
+
+## 5) Changelog and Release Notes Draft Status
+
+Primary sources:
+
+- Changelog: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md
+- Release notes draft: https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-notes/release-notes-draft.md
+
+Current changelog state:
+
+- includes `v1.36.0-alpha.1`
+- includes `v1.36.0-alpha.2`
+- no final `v1.36.0` section yet (expected at/near GA)
+
+Release notes draft includes major sections already:
+
+- Urgent Upgrade Notes
+- Changes by Kind (Dependency / Deprecation / API Change / Feature / Failing Test / Bug or Regression / Other)
+
+High-signal upgrade/risk notes already present:
+
+- Scheduler plugin interface changes (PreBind parallel opt-in, PostFilterResult change)
+- kubeadm removes integrated flex-volume support
+- `git-repo` volume plugin disabled by default and cannot be re-enabled
+- multiple API/client-go behavior and feature-gate lock changes
+
+## 6) Release Highlights Discussion (Direct Input for Blog Angle)
+
+Discussion thread:
+
+- https://github.com/kubernetes/sig-release/discussions/2958
+
+Thread metadata:
+
+- created: 2026-02-11
+- highlights submission deadline in body: 2026-03-31
+
+Current comments found in thread snapshot:
+
+1. SIG Network highlight:
+- KEP-4858 IP/CIDR validation improvements to Beta
+- focus: canonical formats, security/interoperability
+
+2. SIG Storage highlight set:
+- KEP-3476 VolumeGroupSnapshot (target GA)
+- KEP-5538 ServiceAccount token via secrets for CSI (target GA)
+- KEP-4876 Mutable volume attach limits (target GA)
+- KEP-1710 SELinux relabeling improvements (target GA)
+- driver disable callout: `gitRepo` plugin disabled in 1.36
+
+Raw snapshots are saved in:
+
+- `data/sig-release-discussion-2958.json`
+- `data/sig-release-discussion-2958-comments.json`
+
+## 7) Enhancements Inventory Snapshot (Milestone v1.36)
+
+Raw data file:
+
+- `data/enhancements-v1.36-tracked.json`
+
+Collection method:
+
+- open issues in `kubernetes/enhancements` with `tracked/yes`
+- filtered to milestone title `v1.36`
+
+Counts:
+
+- tracked+milestone=v1.36: 78
+- stage/alpha: 31
+- stage/beta: 25
+- stage/stable: 18
+- stage/unknown: 4
+
+Top SIG distribution (count among these 78):
+
+- sig/node: 35
+- sig/scheduling: 17
+- sig/api-machinery: 11
+- sig/auth: 11
+- sig/storage: 9
+
+`stage/unknown` items (worth manual check later):
+
+- #5732 Topology-aware workload scheduling
+- #5710 Workload-aware preemption
+- #5681 Conditional Authorization
+- #5679 HPA External Metrics Fallback on Retrieval Failure
+
+Tracked items with `milestone == null` seen in source pull (important for watchlist):
+
+- #5707 Deprecate `service.spec.externalIPs`
+- #4858 IP/CIDR validation improvements
+
+## 8) Candidate Topics to Prioritize in Future Blog Draft (Not Drafted Yet)
+
+From stable-targeted tracked enhancements and current notes, high-probability candidates include:
+
+- KEP-3962 Mutating Admission Policies (GA)
+- KEP-5589 Remove gogo protobuf dependency
+- KEP-5538 CSI driver SA token via secrets
+- KEP-4876 Mutable CSINode allocatable
+- KEP-3476 VolumeGroupSnapshot
+- KEP-2258 Node log query
+- KEP-1710 SELinux relabel speedup
+- KEP-127 User Namespaces in pods
+
+From beta-targeted tracked enhancements (probable mention set):
+
+- KEP-4006 Transition from SPDY to WebSockets
+- KEP-5311 Relaxed validation for Service names
+- KEP-5284 Constrained Impersonation
+- KEP-4680 Resource Health Status (device plugin/DRA)
+- KEP-4827/4828 Statusz and Flagz
+- KEP-5040 Remove gitRepo volume driver
+
+## 9) Related Upstream Website Signals
+
+Notable open PRs in `kubernetes/website`:
+
+- Mid-cycle/sneak peek WIP: https://github.com/kubernetes/website/pull/54866
+  - file path in PR: `content/en/blog/_posts/2026/kubernetes-v1-36-sneak-peak.md`
+- additional v1.36 related docs/blog placeholders are also open (multiple PRs)
+
+This indicates upstream messaging is still in-flight, so final wording should be re-checked near GA.
+
+## 10) Known-Issue Tracking Status (Current Snapshot)
+
+Searches in `kubernetes/kubernetes` did not return v1.36-specific `known issue` results yet.
+
+Interpretation for now:
+
+- no explicit v1.36 known-issue ticket surfaced by the queries used in this snapshot
+- still needs final check near GA day before publishing
+
+## 11) Release Exception Context (Potential Risk/Story Input)
+
+Source:
+
+- https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/exceptions.yaml
+
+Enhancements freeze exceptions recorded there include approved and rejected requests.
+This can be used later for "what slipped/what got in" context if needed.
+
+## 12) Gaps To Re-Check Right Before Writing (Step 2/3)
+
+1. final release blog URL and final theme/logo assets
+2. final CHANGELOG `v1.36.0` section (replace alpha-only assumptions)
+3. final release notes draft vs final notes differences
+4. v1.36 known issues (if any appear close to release)
+5. whether milestone issue counts and tracked enhancements changed materially
+
+---
+
+This file is intentionally research-only and can be treated as source material for:
+
+- step 2: English blog drafting
+- step 3: Chinese blog drafting
+


### PR DESCRIPTION
## Summary
- add docs/kubernetes/sig-release/v1.36 from DaoCloud-OpenSource/docs
- include 5 markdown docs and 3 JSON data files
- keep source path and file content consistent with upstream

## Validation
- checked file list under v1.36 (8 files)
- verified local file sizes match upstream GitHub API metadata (8/8 OK)