### PR TITLE
docs(kubernetes): curate v1.36 AI infra relevant updates

### DIFF
--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2025-12-17
+last_updated: 2026-04-07
 tags: kubernetes, ai-infrastructure, scheduling, resource-management
 canonical_path: docs/kubernetes/README.md
 ---
@@ -50,6 +50,9 @@ workload isolation.
   remediation strategies
 - **[Node Resource Interface (NRI)](./nri.md)**: Fine-grained container
   resource management at the runtime level
+- **[Kubernetes v1.36 AI Infra Highlights](./v1.36-ai-infra-highlights.md)**:
+  Curated v1.36 release signals focused on AI infrastructure relevance,
+  upgrade risks, and recommended actions
 
 #### Workload Isolation
 

--- a/docs/kubernetes/v1.36-ai-infra-highlights.md
+++ b/docs/kubernetes/v1.36-ai-infra-highlights.md
@@ -1,0 +1,125 @@
+---
+status: Active
+maintainer: pacoxu
+last_updated: 2026-04-07
+tags: kubernetes, release, ai-infrastructure, scheduling, dra, security
+canonical_path: docs/kubernetes/v1.36-ai-infra-highlights.md
+---
+
+# Kubernetes v1.36: AI Infra Highlights (Curated)
+
+This note only syncs v1.36 changes that have direct impact on AI
+infrastructure engineering. It intentionally filters out generic release
+materials and raw collection data.
+
+## Curation Scope
+
+- Keep: changes affecting GPU/heterogeneous resource management, scheduling,
+  multi-tenant security, control-plane scalability, and AI workload recovery.
+- Filter out: community participation content, release process narrative, and
+  raw scrape artifacts that are not directly actionable for AI infra.
+
+## High-Impact Items For AI Infra
+
+### 1) Dynamic Resource Allocation (DRA) keeps expanding
+
+- **Device taints and tolerations (Beta, KEP-5055)**:
+  improve safe scheduling on problematic or constrained devices.
+- **Partitionable devices (KEP-4815)**:
+  enables sharing a single accelerator as logical slices.
+- **AdminAccess for ResourceClaims (Stable, KEP-5018)**:
+  allows operational access to claimed devices for diagnostics and repair.
+
+**AI infra impact**: better GPU sharing efficiency and safer operations in
+multi-tenant clusters.
+
+### 2) Workload-aware scheduling direction stays central
+
+SIG Scheduling highlights Workload Aware Scheduling related work (for example,
+topology-aware scheduling and workload-aware preemption discussions).
+
+**AI infra impact**: better fit for gang-like training jobs and topology-aware
+placement in heterogeneous GPU clusters.
+
+### 3) VolumeGroupSnapshot toward GA (KEP-3476)
+
+Group snapshot/restore for multiple related volumes targets crash-consistent
+recovery points.
+
+**AI infra impact**: improves checkpoint and state recovery workflows for
+multi-volume training/inference services.
+
+### 4) SELinux relabeling performance (GA, KEP-1710)
+
+Mount-option-based labeling reduces recursive relabel overhead.
+
+**AI infra impact**: helps reduce Pod startup latency variance on
+security-enabled nodes.
+
+### 5) Mutating Admission Policies GA (KEP-3962)
+
+CEL-based mutating policies become stable, reducing reliance on external
+mutating webhooks for common policy logic.
+
+**AI infra impact**: lower control-plane extension complexity and fewer webhook
+failure modes at scale.
+
+### 6) ServiceAccount token external signing GA (KEP-740)
+
+Kube-apiserver can delegate token signing to external KMS/HSM systems.
+
+**AI infra impact**: stronger key governance for regulated multi-cluster AI
+platforms.
+
+### 7) Upgrade-risk items that matter operationally
+
+- **`Service.spec.externalIPs` deprecated in v1.36 (KEP-5707)**:
+  plan migration before long-term removal.
+- **`gitRepo` volume driver permanently disabled (KEP-5040)**:
+  replace with `initContainer`, image build-time packaging, or `git-sync`.
+- **Ingress NGINX project retirement (2026-03)**:
+  reassess ingress maintenance and security posture.
+
+**AI infra impact**: avoids avoidable upgrade regressions in shared platform
+entry and workload bootstrap paths.
+
+### 8) Control-plane and upgrade stability signals
+
+- Mixed Version Proxy (Beta, KEP-4020) helps version-skew upgrade windows.
+- Control-plane scalability work (for example KEP-5647/5866 directions) keeps
+  improving large-cluster list/watch behavior.
+
+**AI infra impact**: better reliability during rolling upgrades and high-scale
+operations.
+
+## What Was Filtered Out
+
+- Community participation sections and communication channels.
+- Release timeline/process narrative not needed for infra decisions.
+- Raw collection JSON and issue-board snapshots that are not directly used by
+  this repository's technical guides.
+
+## Recommended Next Actions
+
+1. Validate DRA taints/tolerations and partitioning on a staging GPU cluster.
+2. Audit and migrate any remaining `externalIPs` and `gitRepo` usage.
+3. Pilot Mutating Admission Policies for low-risk policy classes.
+4. Run checkpoint recovery drills with VolumeGroupSnapshot candidates.
+5. Add upgrade playbooks for mixed-version control-plane windows.
+
+## References
+
+- <https://kubernetes.io/blog/2026/03/30/kubernetes-v1-36-sneak-peek/>
+- <https://github.com/kubernetes/sig-release/discussions/2958>
+- <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/README.md>
+- <https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md>
+- <https://kep.k8s.io/5055>
+- <https://kep.k8s.io/4815>
+- <https://kep.k8s.io/5018>
+- <https://kep.k8s.io/3476>
+- <https://kep.k8s.io/1710>
+- <https://kep.k8s.io/3962>
+- <https://kep.k8s.io/740>
+- <https://kep.k8s.io/5707>
+- <https://kep.k8s.io/5040>
+- <https://kep.k8s.io/4020>


### PR DESCRIPTION
## Summary
- close previous raw sync approach and replace with curated sync
- add `docs/kubernetes/v1.36-ai-infra-highlights.md` with only AI infra relevant v1.36 signals
- update `docs/kubernetes/README.md` to add navigation entry

## Filtering rule applied
- keep only items directly impacting AI infra: scheduling, DRA/GPU resource management, security/isolation, control-plane scalability, upgrade risk
- filter out generic release narrative, community sections, and raw data artifacts

## Notes
- this PR intentionally does **not** import `docs/kubernetes/sig-release/v1.36/data/*.json` and related raw source files
- release-day final details should still be cross-checked against upstream changelog/release notes