### PR TITLE
docs(blog): add Chinese translation for SIG etcd spotlight

### DIFF
--- a/docs/blog/2026-04-14/2026-04-14-sig-etcd-spotlight_zh.md
+++ b/docs/blog/2026-04-14/2026-04-14-sig-etcd-spotlight_zh.md
@@ -1,0 +1,129 @@
+---
+status: Active
+maintainer: pacoxu
+date: 2026-04-14
+tags: kubernetes, etcd, sig-etcd, community, open-source
+canonical_path: docs/blog/2026-04-14/2026-04-14-sig-etcd-spotlight_zh.md
+source_urls:
+  - https://kubernetes.io/blog/2025/03/04/sig-etcd-spotlight/
+---
+
+# 聚焦 SIG etcd：从稳定性到社区协作的一线观察（中文整理）
+
+这篇文章整理自 Kubernetes 官方博客在 **2025 年 3 月 4 日**发布的访谈：
+[Spotlight on SIG etcd](https://kubernetes.io/blog/2025/03/04/sig-etcd-spotlight/)。
+
+原文通过对 SIG etcd 核心维护者的访谈，讨论了三个关键问题：
+
+- SIG etcd 为什么会成立；
+- 成为 Kubernetes SIG 之后带来了什么变化；
+- 未来 etcd 在可靠性、可扩展性和社区协作上的重点方向。
+
+## 访谈嘉宾
+
+- **James Blair**（SIG etcd 联合主席，etcd maintainer，Red Hat）
+- **Marek Siarkowicz**（SIG etcd lead，Google）
+- **Wenjia Zhang**（SIG etcd 联合主席，etcd maintainer，Google）
+- **Benjamin Wang**（SIG etcd Tech Lead，etcd maintainer，Broadcom/VMware）
+
+## 为什么要成立 SIG etcd
+
+访谈里给出的核心背景很直接：**etcd 是 Kubernetes 的关键数据存储层，但历史上曾面临维护者流动与可靠性挑战**。在这种情况下，把 etcd 纳入 Kubernetes SIG 体系，主要是为了得到更明确的治理与工程机制。
+
+Marek 的总结是：成立 SIG etcd 后，可以把问题从“靠少数核心维护者支撑”转为“可持续、可协作的工程体系”，并让 etcd 的演进和 Kubernetes 生态保持同步。
+
+## 成为 SIG 之后，具体改善了什么
+
+### 1. 工程流程更标准化
+
+SIG etcd 采用了 Kubernetes 常见机制，包括：
+
+- KEP（Kubernetes Enhancement Proposals）
+- PRR（Production Readiness Review）
+
+这直接影响了特性设计、发布节奏和跨团队协作质量。
+
+### 2. 测试与验证基础设施升级
+
+访谈中特别强调了 Kubernetes 测试体系带来的变化：
+
+- [Prow](https://docs.prow.k8s.io/)
+- [TestGrid](https://testgrid.k8s.io/)
+
+对于 etcd 这类关键基础组件，这类工具价值很大：不仅提升了质量门槛，也降低了外部贡献者参与门槛。
+
+### 3. 跨 SIG 协作更顺畅
+
+SIG etcd 与多个 SIG 保持稳定协作，重点包括：
+
+- SIG API Machinery
+- SIG Scalability
+- SIG Testing
+- SIG Cluster Lifecycle
+
+原文还提到，SIG etcd 与 SIG Cluster Lifecycle 共同推进了 etcd Operator Working Group，这属于“治理机制转化为具体协作产出”的代表案例。
+
+## 社区活跃度：贡献者趋势正在回升
+
+访谈给出了两张趋势图，显示 etcd 社区贡献有明显回升迹象：
+
+- 独立 PR 作者数出现历史高点（原文提到 2025 年 3 月达到新高）；
+- 全仓库贡献活动也呈上升趋势。
+
+![etcd unique PR authors trend](https://kubernetes.io/blog/2025/03/04/sig-etcd-spotlight/stats.png)
+
+![etcd overall contributions trend](https://kubernetes.io/blog/2025/03/04/sig-etcd-spotlight/stats2.png)
+
+## SIG etcd 的近期重点
+
+访谈中多位维护者反复强调：**可靠性仍然是第一优先级**。在此基础上，短期重点包括：
+
+- 持续提升 etcd 的可维护性与可理解性；
+- 优化面向运维侧的使用与管理体验；
+- 支撑更大规模云原生场景下的扩展需求；
+- 在“作为 Kubernetes 关键组件”之外，探索 etcd 作为更通用基础设施能力的可行性。
+
+一句话概括：不是只追求“新功能数量”，而是优先保证正确性、兼容性和长期可运行性。
+
+## 如何参与 SIG etcd
+
+原文给出的参与路径非常务实，适合不同经验层级：
+
+- 参加 [SIG etcd 例会](https://github.com/kubernetes/community/blob/master/sig-etcd/README.md#meetings)
+- 关注 [etcd-dev 邮件组](https://groups.google.com/g/etcd-dev)
+- 查看 [etcd issues](https://github.com/etcd-io/etcd/issues)
+- 从 `good first issue` / `help wanted` 开始
+- 参与测试、代码评审与文档改进
+- 在社区渠道（含 Slack）帮助回答问题
+
+Wenjia 还特别提到 mentorship（导师计划）对新贡献者很有帮助，这也说明社区在“引入新维护者”上是有组织投入的。
+
+## 给新成立 SIG 的建议（可迁移经验）
+
+访谈最后给出的建议，对其他新 SIG 也很通用：
+
+- 尽量复用大社区已有流程，不要重复造治理机制；
+- 主动和相关 SIG 建立协作接口；
+- 把“建设可持续社区”当成和写代码同等重要的工程任务。
+
+## 小结
+
+这篇访谈提供了一个很清晰的信号：
+
+**SIG etcd 的价值，不只是让 etcd 有了新组织名称，而是把关键基础组件的开发、测试、发布和社区协作放进了更可持续的框架。**
+
+对 Kubernetes 使用者来说，这通常意味着两件事：
+
+- etcd 的演进更可预期；
+- 生态协作（尤其与 API Machinery、Cluster Lifecycle 等方向）会更紧密。
+
+## 参考
+
+- Kubernetes Blog:
+  [Spotlight on SIG etcd](https://kubernetes.io/blog/2025/03/04/sig-etcd-spotlight/)
+- etcd website:
+  [https://etcd.io/](https://etcd.io/)
+- etcd GitHub repository:
+  [https://github.com/etcd-io/etcd](https://github.com/etcd-io/etcd)
+- etcd community:
+  [https://etcd.io/community/](https://etcd.io/community/)

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-04-06
+last_updated: 2026-04-14
 tags: blog, kubernetes, ai-infrastructure
 ---
 
@@ -11,6 +11,23 @@ Older posts have been archived to [docs/archive-blog](../archive-blog/README.md)
 
 This directory contains blog posts and articles about AI infrastructure,
 Kubernetes scheduling, and related topics.
+
+## 2026-04-14: 聚焦 SIG etcd（中文整理）
+
+- [聚焦 SIG etcd：从稳定性到社区协作的一线观察（中文整理）](./2026-04-14/2026-04-14-sig-etcd-spotlight_zh.md)
+
+A Chinese summary and translation of Kubernetes Blog's SIG etcd spotlight,
+focused on why SIG etcd was formed and what changed after it joined the SIG
+governance model:
+
+- **Why SIG etcd was created**: etcd is critical to Kubernetes and needed a
+  more sustainable maintenance and reliability model.
+- **What improved after SIG adoption**: clearer process via KEP/PRR, stronger
+  quality infra via Prow/TestGrid, and tighter cross-SIG collaboration.
+- **Community momentum**: highlights contribution trends and increased PR
+  author activity from the official spotlight data.
+- **Actionable participation paths**: meetings, mailing list, issue triage,
+  code/tests/docs, and mentorship-driven onboarding.
 
 ## 2026-04-06: GPU Pod 冷启动优化：AI 工作负载的性能突破
 


### PR DESCRIPTION
## Summary
- add a new Chinese blog post translating and summarizing Kubernetes blog `Spotlight on SIG etcd`
- include key context on SIG formation, governance/process changes, community momentum, and participation paths
- update `docs/blog/README.md` index and `last_updated` date

## Files
- `docs/blog/2026-04-14/2026-04-14-sig-etcd-spotlight_zh.md`
- `docs/blog/README.md`

## Source
- https://kubernetes.io/blog/2025/03/04/sig-etcd-spotlight/