### PR TITLE
docs(inference): add kube-agentic-networking guide

### DIFF
--- a/docs/inference/README.md
+++ b/docs/inference/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-04-06
+last_updated: 2026-04-14
 tags: inference, llm, vllm, serving, optimization
 canonical_path: docs/inference/README.md
 ---
@@ -16,6 +16,7 @@ More details about specific platforms and techniques:
 - [Model Architectures (Llama, Qwen, DeepSeek, Flux)](./model-architectures.md)
 - [LoRA: Low-Rank Adaptation for Efficient LLM Serving](./lora.md)
 - [Grove: Kubernetes API for Inference Orchestration](./grove.md)
+- [kube-agentic-networking: Agentic Networking Governance](./kube-agentic-networking.md)
 - [OME: Kubernetes Operator for LLM Management](./ome.md)
 - [Serverless AI Inference (Knative, AWS SageMaker, Platform Comparison)](./serverless.md)
 - [Model Switching and Dynamic Scheduling (Aegaeon, vLLM Sleep Mode)](./model-switching.md)
@@ -73,6 +74,7 @@ Components that handle request routing, load balancing, and P/D disaggregation:
 | --- | --- | --- |
 | Gateway API Inference Extension | Kubernetes SIG | Inference-aware routing via Gateway API |
 | AIBrix Gateway | AIBrix | LLM-aware routing, load balancing, prefix caching |
+| kube-agentic-networking | Kubernetes SIGs | Agentic networking policy and governance for agent-to-tool/API traffic |
 | Kthena Router | Kthena | Topology-aware P/D routing |
 | LMCache | [LMCache](https://github.com/LMCache/LMCache) | KV cache offloading and reuse |
 | Mooncake | [Moonshot AI](https://github.com/kvcache-ai/Mooncake) | KV cache-centric disaggregated inference |
@@ -122,6 +124,25 @@ autoscaling, and explicit startup ordering.
 - **Single CRD** – entire inference system described in one `PodCliqueSet` CR
 
 For detailed information, see [Grove: Kubernetes Inference Orchestration](./grove.md).
+
+### kube-agentic-networking
+
+[`kube-agentic-networking`](https://github.com/kubernetes-sigs/kube-agentic-networking)
+focuses on network policy and governance for agent workflows on Kubernetes.
+This helps platform teams control and audit how agents access tools, APIs,
+and inference endpoints in multi-tenant environments.
+
+**Key highlights:**
+
+- **Agent-aware network governance**: policy boundaries for agent-to-tool/API
+  traffic
+- **Kubernetes-native posture**: designed to fit existing cluster policy and
+  platform operations
+- **Security and compliance fit**: improves least-privilege controls and
+  auditability for agentic systems
+
+For detailed information, see
+[kube-agentic-networking: Agentic Networking Governance](./kube-agentic-networking.md).
 
 ### Kthena
 

--- a/docs/inference/kube-agentic-networking.md
+++ b/docs/inference/kube-agentic-networking.md
@@ -1,0 +1,72 @@
+---
+status: Active
+maintainer: pacoxu
+last_updated: 2026-04-14
+tags: inference, kubernetes, agentic, networking, governance
+canonical_path: docs/inference/kube-agentic-networking.md
+---
+
+# kube-agentic-networking: Agentic Networking Governance on Kubernetes
+
+[`kube-agentic-networking`](https://github.com/kubernetes-sigs/kube-agentic-networking)
+is a Kubernetes SIG project focused on networking policies and governance for
+agent workloads. In practice, it targets a common problem in agent platforms:
+agents must call many tools and APIs, but platform teams still need clear
+boundaries, least-privilege controls, and auditability.
+
+## Why It Matters
+
+Agent systems are different from traditional microservices:
+
+- **Dynamic egress patterns**: tool calls are often decided at runtime rather
+  than fixed at deploy time.
+- **Cross-domain access**: one workflow may touch model endpoints, MCP tools,
+  external APIs, and internal services.
+- **Governance requirements**: enterprise environments require policy controls,
+  traceability, and tenant isolation for agent actions.
+
+`kube-agentic-networking` addresses these needs by bringing agent-aware
+networking governance into Kubernetes-native workflows.
+
+## Role in the AI Infra Stack
+
+Within this repository's AI infra model, `kube-agentic-networking` sits between:
+
+- **Agent runtimes/orchestrators** (Dify, AgentScope, LangGraph-style systems)
+- **Gateway and routing layers** (AI gateway, inference routing)
+- **Tool backends and external APIs** (MCP servers, internal platforms, SaaS)
+
+It complements API gateways and agent protocols (for example MCP/A2A) by
+focusing on network policy boundaries and governance posture.
+
+## Typical Use Cases
+
+- **Multi-tenant agent platform**: enforce namespace/team boundaries so one
+  team's agent cannot reach another team's internal tools by default.
+- **Controlled tool access**: allow only approved tool/API targets for specific
+  agent classes.
+- **Compliance and audit**: record and review network intent and access
+  patterns for high-risk workflows.
+
+## Adoption Guidance
+
+For production rollout, a pragmatic sequence is:
+
+1. Start with non-production agent workflows and define an explicit tool/API
+   access inventory.
+2. Apply least-privilege network policies for agent workloads first.
+3. Add policy validation and observability before broad rollout.
+4. Expand to multi-tenant and regulated workloads once policy drift and false
+   positives are controlled.
+
+## Learning Topics
+
+- Policy design for agent-to-tool traffic
+- Multi-tenant boundary modeling in Kubernetes
+- Governance integration with AI gateway and protocol layers
+- Operational observability for agent network access
+
+## References
+
+- [GitHub: kubernetes-sigs/kube-agentic-networking](https://github.com/kubernetes-sigs/kube-agentic-networking)
+- [Kubernetes SIGs](https://github.com/kubernetes-sigs)


### PR DESCRIPTION
## Summary
- add a dedicated doc page: docs/inference/kube-agentic-networking.md
- link the new page from docs/inference/README.md
- add kube-agentic-networking to the Orchestration & Routing landscape table
- add a short Featured section entry for kube-agentic-networking
- update docs/inference/README.md last_updated to 2026-04-14

## Why
kube-agentic-networking is already part of the AI infra landscape and should have a first-class documentation entry for discovery and learning path continuity.