### PR TITLE
docs: add AML vs PAI architecture comparison and gap backlog

### DIFF
--- a/case-study/README.md
+++ b/case-study/README.md
@@ -5,6 +5,7 @@
 ## 公司列表
 
 - [字节跳动](./bytedance.md)
+- [AML vs PAI 对照架构](./aml-vs-pai.md)
 - [华为](./huawei.md)
 - [DaoCloud](./daocloud.md)
 - [阿里巴巴](./alibaba.md)

--- a/case-study/aml-vs-pai.md
+++ b/case-study/aml-vs-pai.md
@@ -1,0 +1,134 @@
+---
+status: Active
+maintainer: pacoxu
+last_updated: 2026-04-14
+tags: case-study, bytedance, alibaba, aml, pai, architecture
+canonical_path: case-study/aml-vs-pai.md
+---
+
+# AML vs PAI 对照架构图（2026-04 快照）
+
+## 1. 范围与口径
+
+本文对比以下两个“云上机器学习平台”产品体系：
+
+- **ByteDance / 火山引擎 AML/MLP**（公开文档中常见“机器学习平台”表述）
+- **阿里云 PAI（Platform for AI）**
+
+对比目标：从“AI 平台工程”视角抽象可复用能力，而非做单点功能评测。
+
+## 2. 分层对照（平台工程视角）
+
+| 分层 | AML（火山引擎） | PAI（阿里云） | AI-Infra 当前覆盖 |
+| --- | --- | --- | --- |
+| 业务/方案层 | 行业场景化落地 | 行业场景化解决方案 | 弱（缺统一方法论） |
+| 应用接入层 | Web / OpenAPI / CLI / Python SDK | 控制台 + API + 各类产品集成 | 中 |
+| 平台工具层 | 开发机、Job 训练、工作流、在线服务、模型管理、实验管理 | iTAG、Designer、DSW、DLC、FeatureStore、EAS | 弱（缺平台化闭环章节） |
+| 加速与稳定层 | BytePS、veGiantModel、RDMA、xLLM、监控诊断 | EPL/TorchAcc/Rapidformer、BladeLLM、AIMaster、EasyCkpt | 中（偏引擎/调度，缺平台编排） |
+| 资源治理层 | 资源组/资源队列/优先级/闲时任务/GPU 碎片治理 | 资源池 + 训练/服务资源调度 | 弱（缺资源治理模型） |
+| 基础资源层 | GPU/CPU/RDMA + TOS/CloudFS/vePFS/NAS | GPU/CPU/RDMA/ACK + MaxCompute/Flink | 中 |
+
+## 3. AML vs PAI 对照架构图（Mermaid）
+
+```mermaid
+flowchart LR
+  subgraph AML["ByteDance AML / MLP（火山引擎）"]
+    subgraph AML_APP["接入层"]
+      AML_UI["Web / OpenAPI / CLI / Python SDK"]
+    end
+    subgraph AML_TOOL["平台工具层"]
+      AML_DEV["开发机（WebIDE / Jupyter / SSH）"]
+      AML_JOB["Job 化训练（PyTorchDDP/MPI/BytePS/Ray）"]
+      AML_WF["工作流（YAML / Pipeline）"]
+      AML_EXP["实验管理（记录/归档/对比）"]
+      AML_MODEL["模型管理（导入/评测/版本）"]
+      AML_SERVE["在线服务（流量策略/扩缩容/压测）"]
+    end
+    subgraph AML_ACCEL["加速与稳定层"]
+      AML_TRAIN_ACCEL["BytePS / veGiantModel / RDMA 优化"]
+      AML_INFER_ACCEL["xLLM（PD 分离等）"]
+      AML_OBS["监控/告警/诊断/Hang 检测"]
+    end
+    subgraph AML_GOV["资源治理层"]
+      AML_RG["资源组"]
+      AML_RQ["资源队列"]
+      AML_SCHED["优先级/排队/闲时任务/GPU 碎片治理"]
+    end
+    subgraph AML_INFRA["基础资源层"]
+      AML_COMPUTE["GPU / CPU / RDMA / K8s"]
+      AML_STORAGE["TOS / CloudFS / vePFS / NAS"]
+    end
+  end
+
+  subgraph PAI["Alibaba Cloud PAI"]
+    subgraph PAI_APP["应用与业务层"]
+      PAI_SOLUTION["场景化解决方案 / MaaS 平台集成"]
+    end
+    subgraph PAI_TOOL["平台工具层"]
+      PAI_DATA["数据准备（iTAG / 数据集）"]
+      PAI_DEV["开发建模（Designer / DSW）"]
+      PAI_TRAIN["训练（DLC）"]
+      PAI_FEAT["FeatureStore"]
+      PAI_SERVE["模型在线服务（EAS）"]
+    end
+    subgraph PAI_ACCEL["加速与稳定层"]
+      PAI_TRAIN_ACCEL["EPL / TorchAcc / Rapidformer"]
+      PAI_INFER_ACCEL["BladeLLM / PAI-Blade"]
+      PAI_FT["AIMaster / EasyCkpt"]
+    end
+    subgraph PAI_INFRA["基础资源层"]
+      PAI_RESOURCE["灵骏/通用算力 + ACK + RDMA + MaxCompute/Flink"]
+    end
+  end
+
+  AML_DEV -. 对位 .-> PAI_DEV
+  AML_JOB -. 对位 .-> PAI_TRAIN
+  AML_SERVE -. 对位 .-> PAI_SERVE
+  AML_EXP -. MLOps 对位 .-> PAI_FEAT
+  AML_TRAIN_ACCEL -. 训练加速对位 .-> PAI_TRAIN_ACCEL
+  AML_INFER_ACCEL -. 推理加速对位 .-> PAI_INFER_ACCEL
+  AML_OBS -. 稳定性对位 .-> PAI_FT
+  AML_COMPUTE -. 资源底座 .-> PAI_RESOURCE
+```
+
+## 4. 共性能力与关键差异
+
+### 共性（两者都成熟）
+
+- 训练、推理、工作流、模型管理的端到端平台化
+- 分布式训练与推理加速能力内建
+- 面向大规模 GPU 的资源池与调度优化
+- 平台可观测与稳定性能力（监控、日志、容错）
+
+### 差异（对学习仓库最有价值）
+
+- **PAI 的“产品模块命名与边界”更清晰**：iTAG/DSW/DLC/EAS/FeatureStore 易做标准化教学拆解
+- **AML 的“资源治理与工程实践”暴露更细**：开发机语义、资源组/队列、排队策略、挂载与运维细节更贴近平台实战
+- **推理引擎策略不同**：PAI 强调 BladeLLM 与 EAS 深度耦合；AML 更强调 xLLM 与平台任务体系融合
+
+## 5. 对 AI-Infra 的直接启示（缺口归纳）
+
+当前仓库强项在推理引擎、K8s 调度、GPU 与运行时；弱项在“平台控制面闭环”：
+
+1. 缺统一的 AI 平台分层参考架构（控制面/数据面/治理面）。
+2. 缺资源治理模型（资源组/队列/优先级/成本归因）的实操章节。
+3. 缺数据标注-特征-训练-部署-回流的全流程闭环说明。
+4. 缺实验追踪、模型注册、血缘与复现的工程基线。
+5. 缺训练容错（任务级监控、异步 checkpoint、部分故障恢复）专题。
+6. 缺平台级推理控制面（流量策略、灰度、自动扩缩容、SLO）的章节。
+
+## 6. 参考链接（公开资料）
+
+- 火山引擎机器学习平台功能总览：
+  <https://www.volcengine.com/docs/6459/72379>
+- 火山引擎大规模机器学习平台架构实践：
+  <https://developer.volcengine.com/articles/7098906081463648270>
+- 从字节跳动机器学习平台到火山引擎智能中台：
+  <https://www.volcengine.com/docs/6360/66900>
+- 阿里云 PAI 产品架构：
+  <https://www.alibabacloud.com/help/zh/pai/product-overview/service-architecture>
+- 阿里云 PAI AI 加速：
+  <https://www.alibabacloud.com/help/zh/pai/user-guide/ai-acceleration/>
+- 阿里云 BladeLLM 简介：
+  <https://www.alibabacloud.com/help/zh/pai/user-guide/what-is-bladellm/>
+

--- a/docs/planning/aml-pai-gap-backlog-2026Q2.md
+++ b/docs/planning/aml-pai-gap-backlog-2026Q2.md
@@ -1,0 +1,110 @@
+---
+status: Active
+maintainer: pacoxu
+last_updated: 2026-04-14
+tags: roadmap, backlog, aml, pai, ai-platform-engineering
+canonical_path: docs/planning/aml-pai-gap-backlog-2026Q2.md
+---
+
+# AML vs PAI 视角下的 AI-Infra 补齐 Backlog（2026 Q2）
+
+## 1. 目标
+
+基于 `AML vs PAI` 对照结果，补齐本仓库在“平台控制面闭环”上的短板，
+形成可 issue 化、可验收、可复用的内容增量。
+
+## 2. 优先级总览
+
+| ID | Priority | 缺口主题 | 目标产物 | 建议落位 |
+| --- | --- | --- | --- | --- |
+| GAP-01 | P0 | AI 平台统一分层架构 | 主文档 + 总览图 | `docs/architecture/` |
+| GAP-02 | P0 | 资源治理模型（组/队列/优先级） | 策略文档 + YAML 样例 | `docs/kubernetes/` + `scripts/` |
+| GAP-03 | P0 | 数据-特征-模型闭环 | 参考架构 + 元数据字段模板 | `docs/training/` |
+| GAP-04 | P0 | 实验追踪与模型注册 | MLflow on K8s 最小方案 | `docs/training/` |
+| GAP-05 | P0 | 训练容错与恢复 | 容错模式文档 + 运行手册 | `docs/training/` |
+| GAP-06 | P0 | 推理控制面治理 | 路由/灰度/扩缩容/SLO 基线 | `docs/inference/` |
+| GAP-07 | P1 | AI 存储分层基线 | 存储选型对照 + 压测模板 | `docs/kubernetes/` |
+| GAP-08 | P1 | 平台安全与多租户治理 | 权限/隔离/审计基线 | `docs/kubernetes/` + `agent-infra/` |
+| GAP-09 | P1 | AI FinOps 成本归因 | 指标定义 + 仪表盘草图 | `docs/observability/` |
+| GAP-10 | P1 | 字节 AML 案例深化 | 产品架构深拆文档 | `case-study/` |
+| GAP-11 | P1 | 阿里 PAI 案例深化 | 产品架构深拆文档 | `case-study/` |
+| GAP-12 | P2 | 能力成熟度雷达 | 雷达维度定义 + 数据模板 | `diagrams/` + `docs/planning/` |
+
+## 3. P0 条目（本季度必须落地）
+
+### GAP-01 AI 平台统一分层架构
+
+- 交付物：
+  - `docs/architecture/ai-platform-reference-architecture.md`
+  - 1 张 Mermaid 总览图（控制面/数据面/治理面）
+- 验收标准：
+  - 清晰映射训练、推理、MLOps、资源治理四条主链路
+  - 至少 3 个厂商案例映射（AML、PAI、1 个开源平台）
+
+### GAP-02 资源治理模型（组/队列/优先级）
+
+- 交付物：
+  - `docs/kubernetes/ai-platform-resource-governance.md`
+  - `scripts/governance/` 下最小策略样例（队列、优先级、配额）
+- 验收标准：
+  - 给出“资源组 -> 队列 -> 作业”的策略链
+  - 覆盖抢占、闲时任务、配额超卖边界处理
+
+### GAP-03 数据-特征-模型闭环
+
+- 交付物：
+  - `docs/training/data-feature-model-closed-loop.md`
+  - 元数据模板（数据集版本、特征版本、模型版本、血缘 ID）
+- 验收标准：
+  - 能表达训练/推理一致性（training-serving consistency）
+  - 给出至少 1 个推荐或风控场景示例
+
+### GAP-04 实验追踪与模型注册
+
+- 交付物：
+  - `docs/training/mlflow-k8s-reference.md`
+  - 最小部署与操作流程（实验记录 -> 模型注册 -> 发布）
+- 验收标准：
+  - 提供可复现步骤（命令或 YAML）
+  - 明确“复现失败时”的诊断路径
+
+### GAP-05 训练容错与恢复
+
+- 交付物：
+  - `docs/training/training-fault-tolerance-playbook.md`
+  - 容错策略对照（进程故障、节点故障、网络抖动、GPU XID）
+- 验收标准：
+  - 给出 checkpoint 频率、恢复 RTO 目标建议
+  - 区分“任务级容错”和“平台级容错”的责任边界
+
+### GAP-06 推理控制面治理
+
+- 交付物：
+  - `docs/inference/inference-control-plane-governance.md`
+  - 路由/灰度/扩缩容策略模板（策略示例即可）
+- 验收标准：
+  - 覆盖 TTFT/TPOT/SLA 三类核心目标
+  - 给出“容量不足、抖动、回滚”处理闭环
+
+## 4. 执行波次（12 周）
+
+- Wave 1（第 1-4 周）：`GAP-01` `GAP-02` `GAP-04`
+- Wave 2（第 5-8 周）：`GAP-03` `GAP-05` `GAP-06`
+- Wave 3（第 9-12 周）：`GAP-07` `GAP-08` `GAP-09` + 案例深化与雷达
+
+## 5. Issue 模板建议（每个条目统一）
+
+1. 背景与问题（失败模式 + 影响范围）
+2. 本次目标与非目标
+3. 交付清单（文件路径级）
+4. 验收步骤（成功与失败各至少 1 条）
+5. 回滚与风险（版本、依赖、前置环境）
+
+## 6. 与现有规划文档关系
+
+- 本文是 `AML/PAI` 专题补齐清单
+- 通用季度执行仍以：
+  - `docs/planning/executable-backlog-2026Q2.md`
+  - `RoadMap.md`
+  为主
+

--- a/docs/planning/executable-backlog-2026Q2.md
+++ b/docs/planning/executable-backlog-2026Q2.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-04-03
+last_updated: 2026-04-14
 tags: roadmap, backlog, execution, issues, ai-native
 canonical_path: docs/planning/executable-backlog-2026Q2.md
 ---
@@ -25,7 +25,17 @@ canonical_path: docs/planning/executable-backlog-2026Q2.md
 - 将“建议路径”重映射为当前仓库结构，不强制新增 `talks/` 顶层。
 - 对“状态可能变化”的事实加上快照日期，避免长期误用。
 
-## 3. 执行优先级（主题级）
+## 3. 专题补充（AML vs PAI）
+
+与本清单并行的专题补齐文档：
+
+- `docs/planning/aml-pai-gap-backlog-2026Q2.md`
+- `case-study/aml-vs-pai.md`
+
+该专题聚焦“平台控制面闭环”缺口（资源治理、实验追踪、特征/模型闭环、
+推理控制面），便于后续按优先级拆 issue。
+
+## 4. 执行优先级（主题级）
 
 | ID | 主题 | 优先级 | 目标产物 | 建议落位 |
 | --- | --- | --- | --- | --- |
@@ -43,13 +53,13 @@ canonical_path: docs/planning/executable-backlog-2026Q2.md
 | T12 | Envoy AI Gateway | High | token/cost-aware 网关样例 | `docs/inference/` |
 | T13 | 推理 Conformance 门禁 | High | preflight checklist + probes/gate 模板 | `docs/inference/` + `scripts/` |
 
-## 4. Top 12（建议先开 issue）
+## 5. Top 12（建议先开 issue）
 
 以下条目按“先可观测/安全/评测，再扩展调度与多集群”的原则排序。
 
 ### Wave 1（第 1-4 周）：可观测 + 安全 + 评测
 
-1. `[O01]` OTel GenAI 语义规范落地（Status 快照见第 6 节）
+1. `[O01]` OTel GenAI 语义规范落地（Status 快照见第 7 节）
 2. `[O03]` vLLM 指标与仪表盘对齐
 3. `[H03]` Agent 运行命名空间 PSS 基线
 4. `[H04]` Seccomp `RuntimeDefault` 默认化
@@ -68,7 +78,7 @@ canonical_path: docs/planning/executable-backlog-2026Q2.md
 2. `[N04]` 跨集群统一排队策略
 3. `[D01]` 模型权重统一存储与挂载基线
 
-## 5. Issue 切分格式（统一 DoD）
+## 6. Issue 切分格式（统一 DoD）
 
 每个 issue 使用以下结构：
 
@@ -85,7 +95,7 @@ Definition of Done（统一）：
 - 至少 1 组验证步骤（成功与失败各 1 条）。
 - 明确回滚/清理命令。
 
-## 6. 事实状态快照（需要定期复核）
+## 7. 事实状态快照（需要定期复核）
 
 以下结论仅作为本次规划快照，日期：`2026-04-03`。
 
@@ -96,7 +106,7 @@ Definition of Done（统一）：
 
 建议在每次季度规划时重审此节。
 
-## 7. 仓库落地映射（首批文件建议）
+## 8. 仓库落地映射（首批文件建议）
 
 为兼容当前仓库结构，首批优先新增/更新以下文件：
 
@@ -111,7 +121,7 @@ Definition of Done（统一）：
 - `scripts/conformance/preflight.sh`
 - `scripts/airgapped/sync-models.sh`
 
-## 8. 维护方式
+## 9. 维护方式
 
 - RoadMap 只保留方向与阶段目标，本文件维护执行条目与拆分粒度。
 - 每个条目状态建议采用：`todo` / `in-progress` / `done` / `blocked`。


### PR DESCRIPTION
## Summary
- add AML vs PAI architecture comparison doc with layered mapping and Mermaid diagram
- add AI-Infra gap backlog from AML/PAI perspective (P0/P1/P2, deliverables, acceptance criteria)
- update case-study index and executable backlog doc with links to the new topic

## Changed files
- case-study/aml-vs-pai.md
- docs/planning/aml-pai-gap-backlog-2026Q2.md
- case-study/README.md
- docs/planning/executable-backlog-2026Q2.md

## Notes
- docs-only change, no runtime/test impact