### PR TITLE
docs(ai-infra): add KEP 1.36-aligned PSI/snapshot coverage

### DIFF
--- a/docs/blog/2026-04-15/2026-04-15-kubernetes-v1.34-psi-metrics-beta-ai-infra_zh.md
+++ b/docs/blog/2026-04-15/2026-04-15-kubernetes-v1.34-psi-metrics-beta-ai-infra_zh.md
@@ -1,0 +1,112 @@
+---
+status: Active
+maintainer: pacoxu
+date: 2026-04-15
+tags: kubernetes, psi, cgroupv2, observability, ai-infrastructure, sre
+canonical_path: docs/blog/2026-04-15/2026-04-15-kubernetes-v1.34-psi-metrics-beta-ai-infra_zh.md
+source_urls:
+  - https://github.com/kubernetes/website/pull/51574
+  - https://github.com/kubernetes/enhancements/issues/4205
+  - https://kubernetes.io/docs/reference/instrumentation/understand-psi-metrics/
+  - https://docs.kernel.org/accounting/psi.html
+---
+
+# Kubernetes v1.34 PSI Metrics Beta：AI-Infra 该如何落地
+
+`KEP-4205` 在 Kubernetes `v1.34` 进入 Beta 后，PSI（Pressure Stall
+Information）不再只是 Linux 内核概念，而是可以直接进入 Kubernetes 节点/容器
+观测与告警体系。
+
+对 AI 平台而言，这件事的价值不是“多几个指标”，而是让我们能更早识别
+**GPU 供给正常但 CPU/内存/IO 出现隐形拥塞** 的场景。
+
+## 先说结论
+
+要把 PSI 用起来，至少做三件事：
+
+1. 在 Linux + cgroup v2 节点开启 `KubeletPSI` feature gate。
+2. 接入 `/metrics/cadvisor` 暴露的新指标，并按节点/工作负载分组观察趋势。
+3. 把 PSI 告警接入扩缩容或调度策略，而不是只做 dashboard 展示。
+
+## Upstream PR 里最值得关注的点
+
+来自 `kubernetes/website#51574` 的关键信息：
+
+- `v1.34` 中 PSI metrics 升级到 Beta。
+- kubelet 可通过两条链路暴露 PSI：Summary API 与 `/metrics/cadvisor`。
+- 新增六个核心指标：
+  - `container_pressure_cpu_stalled_seconds_total`
+  - `container_pressure_cpu_waiting_seconds_total`
+  - `container_pressure_memory_stalled_seconds_total`
+  - `container_pressure_memory_waiting_seconds_total`
+  - `container_pressure_io_stalled_seconds_total`
+  - `container_pressure_io_waiting_seconds_total`
+- 依赖前提：Linux kernel `>=4.20` 且使用 cgroup v2。
+- Windows 节点不提供 PSI 指标。
+
+## 为什么 AI 场景更需要 PSI
+
+在推理和训练集群中，常见问题不是资源“用满”而是资源“争用”导致延迟抖动：
+
+- Token 生成延迟突然上升，但 GPU 利用率仍高且稳定。
+- KV cache 命中率没有明显下降，但 p99 延迟持续拉长。
+- 作业吞吐下降，却看不到明显 OOM 或 CPU limit 触顶。
+
+这类问题用传统 utilization 指标很难提前发现。PSI 的 `some/full` 能更快反映
+“任务在等资源”的时间比例。
+
+## 最小落地步骤
+
+### 1) 开启 feature gate
+
+在 kubelet 启动参数中开启：
+
+```bash
+--feature-gates=KubeletPSI=true
+```
+
+### 2) 采集与记录
+
+- Prometheus 抓取 `kubelet /metrics/cadvisor`
+- 保留 `pod`、`namespace`、`node`、`container` 标签
+- 对训练队列与在线推理服务分开看板
+
+### 3) 告警与动作联动
+
+建议先从两类告警开始：
+
+- **Node 级持续压力**：`memory full` 或 `io full` 连续上升
+- **Workload 级异常抖动**：同一 deployment 中 PSI 分布突然分化
+
+示例（仅示意）：
+
+```promql
+rate(container_pressure_memory_stalled_seconds_total{container!=""}[5m]) > 0.2
+```
+
+```promql
+rate(container_pressure_io_waiting_seconds_total{container!=""}[5m]) > 0.15
+```
+
+## 和现有 AI-Infra 能力怎么结合
+
+1. 与调度结合：把高 PSI 节点作为低优先级放置候选。
+2. 与弹性结合：当 PSI 持续偏高而 GPU 未饱和时，优先扩 CPU/内存侧资源。
+3. 与容量规划结合：按业务线比较 PSI 热点节点，识别“伪充足容量”。
+
+## 一份可执行的两周计划
+
+1. 第 1-2 天：确认所有 Linux 节点已切到 cgroup v2。
+2. 第 3-4 天：灰度开启 `KubeletPSI`，验证指标入库完整性。
+3. 第 5-7 天：建立 Node/Pod 双视角 PSI 看板。
+4. 第 8-10 天：配置两条基础告警并做一次演练。
+5. 第 11-14 天：把 PSI 信号接入调度或扩容策略，形成闭环。
+
+## 参考
+
+- Kubernetes Website PR:
+  [Add blog post for PSI Metrics graduate to Beta](https://github.com/kubernetes/website/pull/51574)
+- KEP Issue: [KEP-4205](https://github.com/kubernetes/enhancements/issues/4205)
+- Kubernetes Docs:
+  [Understand PSI Metrics](https://kubernetes.io/docs/reference/instrumentation/understand-psi-metrics/)
+- Linux Kernel Docs: [PSI](https://docs.kernel.org/accounting/psi.html)

--- a/docs/blog/2026-04-15/2026-04-15-volume-group-snapshot-and-cbt-for-ai-checkpoints_zh.md
+++ b/docs/blog/2026-04-15/2026-04-15-volume-group-snapshot-and-cbt-for-ai-checkpoints_zh.md
@@ -1,0 +1,131 @@
+---
+status: Active
+maintainer: pacoxu
+date: 2026-04-15
+tags: kubernetes, storage, csi, snapshot, checkpoint, ai-infrastructure, backup
+canonical_path: docs/blog/2026-04-15/2026-04-15-volume-group-snapshot-and-cbt-for-ai-checkpoints_zh.md
+source_urls:
+  - https://github.com/kubernetes/website/pull/51390
+  - https://github.com/kubernetes/website/pull/48456
+  - https://github.com/kubernetes/enhancements/issues/3476
+  - https://github.com/kubernetes/enhancements/issues/3314
+  - https://github.com/kubernetes-csi/external-snapshotter
+  - https://github.com/kubernetes-csi/external-snapshot-metadata
+---
+
+# 用 VolumeGroupSnapshot + CBT 改善 AI Checkpoint 备份与恢复
+
+在 AI 训练平台里，真正贵的不是“会不会备份”，而是：
+
+- 备份窗口太长，影响训练吞吐；
+- 恢复时间太慢，影响作业 RTO；
+- 全量拷贝太多，导致存储成本与网络成本持续上升。
+
+Kubernetes storage 方向最近两条主线正好对应这些问题：
+
+- `KEP-3476`：VolumeGroupSnapshot（多卷一致性快照）；
+- `KEP-3314`：Changed Block Tracking（块级增量识别，alpha）。
+
+## 先说结论
+
+对 AI-Infra 来说，推荐把二者组合为一个标准流程：
+
+1. 用 VolumeGroupSnapshot 保障多 PVC 的 crash-consistent 恢复点。
+2. 用 CBT 只传输“变化块”，降低增量备份成本。
+3. 恢复时优先按“组快照 + 增量链”回放，而不是每次全量回灌。
+
+## Upstream PR 对应关系
+
+### VolumeGroupSnapshot 线
+
+- Alpha 博客：`website#39415`
+- Beta 博客：`website#48420`
+- v1beta2 博客：`website#51390`
+
+`v1beta2` 的关键信息是：为了解决部分驱动场景下 `restoreSize` 信息缺失问题，
+API 结构升级，引入了更明确的 `VolumeSnapshotInfo` 信息模型，并通过 conversion
+webhook 兼容旧版对象。
+
+### Changed Block Tracking 线
+
+- Alpha 博客：`website#48456`
+
+核心价值：在同一卷的两个快照之间，按 block delta 拉取变化块，不再扫描全卷。
+
+## AI Checkpoint 的典型痛点
+
+一个训练作业经常不是单卷：
+
+- 模型参数卷
+- 优化器状态卷
+- 中间数据或日志卷
+
+如果只做单卷快照，恢复点容易错位；如果每次全量备份，备份窗口与成本都不可控。
+
+## 推荐架构
+
+```text
+训练任务
+  -> 组快照控制器 (VolumeGroupSnapshot)
+  -> 存储侧生成同一时点的多卷快照
+  -> 备份系统调用 SnapshotMetadata API (CBT)
+  -> 仅拉取 changed blocks
+  -> 对象存储形成增量链
+```
+
+恢复路径：
+
+```text
+选择恢复点
+  -> 解析对应 VolumeGroupSnapshot
+  -> 为组内每个卷创建恢复 PVC
+  -> 回放增量块
+  -> 作业从一致性 checkpoint 重启
+```
+
+## 最小实施清单
+
+### 1) 确认 CSI 能力
+
+- CSI 驱动支持 group snapshot API
+- CSI 驱动支持 snapshot metadata/CBT（如果要增量链）
+- 部署 `external-snapshotter` 与 `external-snapshot-metadata` 相关组件
+
+### 2) 先落地组快照
+
+- 定义 `VolumeGroupSnapshotClass`
+- 通过 label selector 把同一个训练任务的 PVC 归组
+- 建立每日/每小时组快照策略
+
+### 3) 再引入 CBT
+
+- 打通 `GetMetadataAllocated` / `GetMetadataDelta` 客户端
+- 备份管道改为“快照 + 块增量”模式
+- 增加 RBAC 与 token 访问控制，避免跨租户读取元数据
+
+## 风险与边界
+
+1. CBT 当前是 alpha，驱动覆盖度和生态成熟度不一。
+2. 不同存储后端对块追踪能力差异很大，先做小规模验证。
+3. 组快照提供的是 crash consistency，不等同应用一致性。
+4. 生产环境需要把“快照成功”与“恢复可用”分开验收。
+
+## 一份可执行的推进节奏
+
+1. 第 1 周：选定 1 个 CSI 驱动与 1 条训练流水线做试点。
+2. 第 2 周：完成组快照创建、恢复演练与 RTO 基线测量。
+3. 第 3 周：接入 CBT 增量链，比较全量/增量的窗口与成本。
+4. 第 4 周：完善 RBAC、审计与跨租户隔离，再逐步扩大覆盖范围。
+
+## 参考
+
+- Kubernetes Website PR:
+  [Volume Group Snapshot v1beta2](https://github.com/kubernetes/website/pull/51390)
+- Kubernetes Website PR:
+  [Changed Block Tracking API (alpha)](https://github.com/kubernetes/website/pull/48456)
+- KEP Issue: [KEP-3476](https://github.com/kubernetes/enhancements/issues/3476)
+- KEP Issue: [KEP-3314](https://github.com/kubernetes/enhancements/issues/3314)
+- CSI External Snapshotter:
+  [kubernetes-csi/external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter)
+- CSI External Snapshot Metadata:
+  [kubernetes-csi/external-snapshot-metadata](https://github.com/kubernetes-csi/external-snapshot-metadata)

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-04-06
+last_updated: 2026-04-15
 tags: blog, kubernetes, ai-infrastructure
 ---
 
@@ -11,6 +11,34 @@ Older posts have been archived to [docs/archive-blog](../archive-blog/README.md)
 
 This directory contains blog posts and articles about AI infrastructure,
 Kubernetes scheduling, and related topics.
+
+## 2026-04-15: Kubernetes v1.34 PSI Metrics Beta（AI-Infra 落地）
+
+- [Kubernetes v1.34 PSI Metrics Beta：AI-Infra 该如何落地 (Chinese)](./2026-04-15/2026-04-15-kubernetes-v1.34-psi-metrics-beta-ai-infra_zh.md)
+
+A Chinese practical guide focused on operationalizing PSI metrics in AI
+clusters after KEP-4205 moved to Beta:
+
+- **From kernel to platform signal**: maps Linux PSI into kubelet Summary API
+  and `/metrics/cadvisor` collection paths.
+- **Actionable observability**: highlights the six PSI Prometheus metrics and
+  proposes node/workload alert starting points.
+- **AI-oriented closed loop**: links PSI pressure to scheduling and scaling
+  decisions instead of keeping it dashboard-only.
+
+## 2026-04-15: VolumeGroupSnapshot + CBT for AI Checkpoints
+
+- [用 VolumeGroupSnapshot + CBT 改善 AI Checkpoint 备份与恢复 (Chinese)](./2026-04-15/2026-04-15-volume-group-snapshot-and-cbt-for-ai-checkpoints_zh.md)
+
+A Chinese implementation note that combines KEP-3476 and KEP-3314 for AI
+training backup and recovery:
+
+- **Consistent multi-volume recovery point**: uses VolumeGroupSnapshot for
+  crash-consistent checkpoints across PVC groups.
+- **Incremental backup path**: introduces changed-block tracking (CBT) to avoid
+  repeated full-volume transfers.
+- **Production rollout framing**: includes driver capability checks, phased
+  adoption, and restore-first validation guidance.
 
 ## 2026-04-06: GPU Pod 冷启动优化：AI 工作负载的性能突破
 

--- a/docs/kubernetes/dra.md
+++ b/docs/kubernetes/dra.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2025-11-25
+last_updated: 2026-04-15
 tags: kubernetes, dra, resource-allocation, device-management, topology
 canonical_path: docs/kubernetes/dra.md
 ---
@@ -136,6 +136,68 @@ awareness:
 - Virtual NIC (vNIC) Sharing
 - Bandwidth-limited Network Allocation
 - I/O Bandwidth Smart Storage Device Sharing
+
+#### What changed in practice (KEP-5075)
+
+Compared with earlier DRA device sharing, Kubernetes 1.34 adds more concrete
+sharing semantics for real multi-tenant use:
+
+- **Cross-claim sharing**: one device (or partition) can be shared by multiple
+  ResourceClaims or DeviceRequests when driver enables
+  `allowMultipleAllocations`.
+- **Capacity-aware scheduling**: scheduler tracks per-device `capacity` usage
+  and prevents over-allocation.
+- **DistinctAttribute constraint**: the opposite of `matchAttribute`, used to
+  ensure request results come from different resources.
+- **ShareID in allocation status**: driver can distinguish multiple shared
+  allocations on the same underlying device.
+
+Feature gate to enable on control plane and node components:
+
+```bash
+--feature-gates=...,DRAConsumableCapacity=true
+```
+
+Driver-side ResourceSlice example (memory as consumable capacity):
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceSlice
+spec:
+  devices:
+  - name: gpu0
+    allowMultipleAllocations: true
+    capacity:
+      memory:
+        value: 40Gi
+        requestPolicy:
+          default: 5Gi
+          validRange:
+            min: 5Gi
+            step: 5Gi
+```
+
+Consumer-side request example:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+spec:
+  devices:
+    requests:
+    - name: req0
+      exactly:
+      - deviceClassName: resource.example.com
+        capacity:
+          requests:
+            memory: 10Gi
+      selectors:
+      - cel:
+          expression: device.allowMultipleAllocations == true
+```
+
+Use `distinctAttribute` when requests must not land on the same underlying
+device (for example different subnets or fault domains).
 
 ### Migration from Device Plugin to DRA
 


### PR DESCRIPTION
## Summary
- enrich DRA docs with KEP-5075 consumable-capacity details (DistinctAttribute, ShareID, requestPolicy, feature gate)
- add new AI-Infra blog on Kubernetes v1.34 PSI metrics beta (KEP-4205) and rollout guidance
- add new AI-Infra blog on VolumeGroupSnapshot + Changed Block Tracking for AI checkpoint backup/recovery (KEP-3476/3314)
- update blog index and last_updated for the two new posts

## Notes
- only these docs files are included in this PR
- left unrelated local working tree changes unstaged