### PR TITLE
[codex] docs(dra): add extended resource flow diagram

### DIFF
--- a/diagrams/dra-extended-resource-flow.mmd
+++ b/diagrams/dra-extended-resource-flow.mmd
@@ -1,0 +1,53 @@
+flowchart LR
+  subgraph APP["Workload"]
+    POD["Pod spec\nlimits: example.com/gpu=1"]
+  end
+
+  subgraph API["API Server + etcd"]
+    DC["DeviceClass\nextendedResourceName mapping"]
+    RS["ResourceSlice\nDRA device inventory per node"]
+    NODECAP["Node.status.capacity\n(device plugin path)"]
+    SRC["Special ResourceClaim\n(created by scheduler)"]
+    PS["Pod.status.extendedResourceClaimStatus\ncontainer/resource -> requestName"]
+  end
+
+  subgraph SCHED["kube-scheduler"]
+    NRF["NodeResourcesFit\nScalarResources + DynamicResources"]
+    DRP["dynamicresources plugin\nPreFilter -> Filter -> Reserve -> PreBind"]
+    ALLOC["DRA allocator\nbuild DeviceRequests + pick devices"]
+  end
+
+  subgraph N1["Node A (DRA-backed extended resource)"]
+    KLET["kubelet DRA manager"]
+    DRIVER["DRA Driver\nPrepareResources"]
+    CDI["CDI handles"]
+    RT["Container Runtime"]
+    CTR["Containers"]
+  end
+
+  subgraph N2["Node B (legacy device plugin)"]
+    DP["Device Plugin"]
+  end
+
+  POD --> NRF
+  DC --> NRF
+  RS --> NRF
+  NODECAP --> NRF
+
+  NRF --> DRP
+  DRP --> ALLOC
+  ALLOC --> SRC
+  DRP --> PS
+
+  PS --> KLET
+  SRC --> KLET
+  KLET --> DRIVER
+  DRIVER --> CDI
+  CDI --> RT
+  RT --> CTR
+
+  NRF -. if node uses device plugin capacity .-> DP
+
+  NOTE["Constraint:\nOne node cannot expose same resource name\nfrom both DRA and Device Plugin"]
+  NOTE -.-> N1
+  NOTE -.-> N2

--- a/diagrams/dra-extended-resource-flow.svg
+++ b/diagrams/dra-extended-resource-flow.svg
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2300 900" width="2300" height="900" role="img" aria-labelledby="title desc">
+  <title id="title">DRA-backed extended resource request flow</title>
+  <desc id="desc">Flow diagram showing how an extended resource request is resolved through DRA, the scheduler, kubelet, and the device plugin fallback path.</desc>
+  <defs>
+    <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2563eb"/>
+    </marker>
+    <marker id="arrow-slate" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+    <marker id="arrow-orange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#d97706"/>
+    </marker>
+  </defs>
+  <style>
+    text {
+      font-family: "Helvetica Neue", Arial, sans-serif;
+      fill: #0f172a;
+    }
+    .group {
+      stroke: #1e293b;
+      stroke-width: 2.5;
+    }
+    .group-title {
+      font-size: 20px;
+      font-weight: 700;
+      text-anchor: middle;
+    }
+    .group-subtitle {
+      font-size: 17px;
+      font-weight: 600;
+      text-anchor: middle;
+      fill: #334155;
+    }
+    .box {
+      fill: #ffffff;
+      stroke: #334155;
+      stroke-width: 2;
+    }
+    .box-title {
+      font-size: 15px;
+      font-weight: 700;
+      text-anchor: middle;
+    }
+    .box-body {
+      font-size: 13px;
+      font-weight: 500;
+      text-anchor: middle;
+      fill: #334155;
+    }
+    .group-workload {
+      fill: #e0f2fe;
+    }
+    .group-api {
+      fill: #ecfeff;
+    }
+    .group-scheduler {
+      fill: #fff7ed;
+    }
+    .group-node-a {
+      fill: #f0fdf4;
+    }
+    .group-node-b {
+      fill: #f8fafc;
+    }
+    .note {
+      fill: #fef3c7;
+      stroke: #d97706;
+      stroke-width: 2.5;
+      stroke-dasharray: 10 8;
+    }
+    .flow {
+      fill: none;
+      stroke: #2563eb;
+      stroke-width: 3;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      marker-end: url(#arrow-blue);
+    }
+    .flow-muted {
+      fill: none;
+      stroke: #64748b;
+      stroke-width: 3;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-dasharray: 10 8;
+      marker-end: url(#arrow-slate);
+    }
+    .note-link {
+      fill: none;
+      stroke: #d97706;
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-dasharray: 8 7;
+      marker-end: url(#arrow-orange);
+    }
+    .edge-label {
+      font-size: 13px;
+      font-weight: 600;
+      fill: #475569;
+      text-anchor: middle;
+    }
+  </style>
+
+  <rect x="0" y="0" width="2300" height="900" fill="#ffffff"/>
+
+  <rect class="group group-workload" x="40" y="80" width="250" height="170" rx="18" ry="18"/>
+  <text class="group-title" x="165" y="120">Workload</text>
+  <rect class="box" x="90" y="145" width="150" height="72" rx="12" ry="12"/>
+  <text class="box-title" x="165" y="174">Pod spec</text>
+  <text class="box-body" x="165" y="198">limits: example.com/gpu=1</text>
+
+  <rect class="group group-api" x="340" y="40" width="650" height="400" rx="18" ry="18"/>
+  <text class="group-title" x="665" y="80">API Server + etcd</text>
+  <rect class="box" x="390" y="100" width="220" height="76" rx="12" ry="12"/>
+  <text class="box-title" x="500" y="129">DeviceClass</text>
+  <text class="box-body" x="500" y="152">extendedResourceName mapping</text>
+  <rect class="box" x="390" y="205" width="220" height="76" rx="12" ry="12"/>
+  <text class="box-title" x="500" y="234">ResourceSlice</text>
+  <text class="box-body" x="500" y="257">DRA device inventory per node</text>
+  <rect class="box" x="680" y="100" width="250" height="76" rx="12" ry="12"/>
+  <text class="box-title" x="805" y="129">Node.status.capacity</text>
+  <text class="box-body" x="805" y="152">(device plugin path)</text>
+  <rect class="box" x="680" y="205" width="250" height="76" rx="12" ry="12"/>
+  <text class="box-title" x="805" y="234">Special ResourceClaim</text>
+  <text class="box-body" x="805" y="257">(created by scheduler)</text>
+  <rect class="box" x="470" y="315" width="390" height="88" rx="12" ry="12"/>
+  <text class="box-title" x="665" y="345">Pod.status.extendedResourceClaimStatus</text>
+  <text class="box-body" x="665" y="368">container/resource -&gt; requestName</text>
+
+  <rect class="group group-scheduler" x="1040" y="110" width="350" height="340" rx="18" ry="18"/>
+  <text class="group-title" x="1215" y="150">kube-scheduler</text>
+  <rect class="box" x="1090" y="175" width="250" height="74" rx="12" ry="12"/>
+  <text class="box-title" x="1215" y="204">NodeResourcesFit</text>
+  <text class="box-body" x="1215" y="227">ScalarResources + DynamicResources</text>
+  <rect class="box" x="1090" y="275" width="250" height="74" rx="12" ry="12"/>
+  <text class="box-title" x="1215" y="304">dynamicresources plugin</text>
+  <text class="box-body" x="1215" y="327">PreFilter -&gt; Filter -&gt; Reserve -&gt; PreBind</text>
+  <rect class="box" x="1090" y="375" width="250" height="74" rx="12" ry="12"/>
+  <text class="box-title" x="1215" y="404">DRA allocator</text>
+  <text class="box-body" x="1215" y="427">build DeviceRequests + pick devices</text>
+
+  <rect class="group group-node-a" x="1470" y="40" width="770" height="390" rx="18" ry="18"/>
+  <text class="group-title" x="1855" y="78">Node A</text>
+  <text class="group-subtitle" x="1855" y="103">(DRA-backed extended resource)</text>
+  <rect class="box" x="1510" y="225" width="120" height="74" rx="12" ry="12"/>
+  <text class="box-title" x="1570" y="254">kubelet</text>
+  <text class="box-body" x="1570" y="277">DRA manager</text>
+  <rect class="box" x="1650" y="225" width="180" height="74" rx="12" ry="12"/>
+  <text class="box-title" x="1740" y="254">DRA Driver</text>
+  <text class="box-body" x="1740" y="277">PrepareResources</text>
+  <rect class="box" x="1850" y="225" width="110" height="74" rx="12" ry="12"/>
+  <text class="box-title" x="1905" y="262">CDI</text>
+  <rect class="box" x="1980" y="225" width="110" height="74" rx="12" ry="12"/>
+  <text class="box-title" x="2035" y="254">Container</text>
+  <text class="box-body" x="2035" y="277">Runtime</text>
+  <rect class="box" x="2110" y="225" width="90" height="74" rx="12" ry="12"/>
+  <text class="box-title" x="2155" y="262">Containers</text>
+
+  <rect class="group group-node-b" x="1470" y="500" width="770" height="160" rx="18" ry="18"/>
+  <text class="group-title" x="1855" y="540">Node B (legacy device plugin)</text>
+  <rect class="box" x="1760" y="560" width="190" height="74" rx="12" ry="12"/>
+  <text class="box-title" x="1855" y="599">Device Plugin</text>
+
+  <rect class="note" x="700" y="580" width="560" height="116" rx="16" ry="16"/>
+  <text class="box-title" x="980" y="614">Constraint:</text>
+  <text class="box-body" x="980" y="639">One node cannot expose the same resource name</text>
+  <text class="box-body" x="980" y="661">from both DRA and Device Plugin.</text>
+
+  <path class="flow" d="M 240 181 L 300 181 L 300 460 L 1060 460 L 1060 212 L 1090 212"/>
+  <path class="flow" d="M 610 138 L 660 138 L 660 212 L 1090 212"/>
+  <path class="flow" d="M 610 243 L 700 243 L 700 212 L 1090 212"/>
+  <path class="flow" d="M 930 138 L 970 138 L 970 212 L 1090 212"/>
+
+  <path class="flow" d="M 1215 249 L 1215 275"/>
+  <path class="flow" d="M 1215 349 L 1215 375"/>
+  <path class="flow" d="M 1090 412 L 1010 412 L 1010 243 L 930 243"/>
+  <path class="flow" d="M 1090 312 L 1020 312 L 1020 359 L 860 359"/>
+
+  <path class="flow" d="M 860 359 L 950 359 L 950 470 L 1430 470 L 1430 262 L 1510 262"/>
+  <path class="flow" d="M 930 243 L 1000 243 L 1000 90 L 1430 90 L 1430 262 L 1510 262"/>
+  <path class="flow" d="M 1630 262 L 1650 262"/>
+  <path class="flow" d="M 1830 262 L 1850 262"/>
+  <path class="flow" d="M 1960 262 L 1980 262"/>
+  <path class="flow" d="M 2090 262 L 2110 262"/>
+
+  <path class="flow-muted" d="M 1340 212 L 1420 212 L 1420 597 L 1760 597"/>
+  <text class="edge-label" x="1590" y="240">if node uses device plugin capacity</text>
+
+  <path class="note-link" d="M 1260 616 L 1410 616 L 1410 240 L 1470 240"/>
+  <path class="note-link" d="M 1260 660 L 1410 660 L 1410 580 L 1470 580"/>
+</svg>

--- a/diagrams/dra-extended-resource-flow.svg
+++ b/diagrams/dra-extended-resource-flow.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2300 900" width="2300" height="900" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2360 980" width="2360" height="980" role="img" aria-labelledby="title desc">
   <title id="title">DRA-backed extended resource request flow</title>
   <desc id="desc">Flow diagram showing how an extended resource request is resolved through DRA, the scheduler, kubelet, and the device plugin fallback path.</desc>
   <defs>
-    <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+    <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#2563eb"/>
     </marker>
-    <marker id="arrow-slate" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
+    <marker id="arrow-slate" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
     </marker>
-    <marker id="arrow-orange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#d97706"/>
+    <marker id="arrow-orange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#f97316"/>
     </marker>
   </defs>
   <style>
@@ -28,7 +28,7 @@
       text-anchor: middle;
     }
     .group-subtitle {
-      font-size: 17px;
+      font-size: 16px;
       font-weight: 600;
       text-anchor: middle;
       fill: #334155;
@@ -43,8 +43,13 @@
       font-weight: 700;
       text-anchor: middle;
     }
+    .box-title-small {
+      font-size: 14px;
+      font-weight: 700;
+      text-anchor: middle;
+    }
     .box-body {
-      font-size: 13px;
+      font-size: 12.5px;
       font-weight: 500;
       text-anchor: middle;
       fill: #334155;
@@ -66,14 +71,14 @@
     }
     .note {
       fill: #fef3c7;
-      stroke: #d97706;
-      stroke-width: 2.5;
-      stroke-dasharray: 10 8;
+      stroke: #f97316;
+      stroke-width: 2.3;
+      stroke-dasharray: 9 7;
     }
     .flow {
       fill: none;
       stroke: #2563eb;
-      stroke-width: 3;
+      stroke-width: 2.8;
       stroke-linecap: round;
       stroke-linejoin: round;
       marker-end: url(#arrow-blue);
@@ -81,114 +86,130 @@
     .flow-muted {
       fill: none;
       stroke: #64748b;
-      stroke-width: 3;
+      stroke-width: 2.6;
       stroke-linecap: round;
       stroke-linejoin: round;
-      stroke-dasharray: 10 8;
+      stroke-dasharray: 9 7;
       marker-end: url(#arrow-slate);
     }
     .note-link {
       fill: none;
-      stroke: #d97706;
-      stroke-width: 2.5;
+      stroke: #f97316;
+      stroke-width: 2.3;
       stroke-linecap: round;
       stroke-linejoin: round;
-      stroke-dasharray: 8 7;
+      stroke-dasharray: 7 6;
       marker-end: url(#arrow-orange);
     }
+    .label-bg {
+      fill: #ffffff;
+      fill-opacity: 0.96;
+      stroke: #cbd5e1;
+      stroke-width: 1.1;
+    }
     .edge-label {
-      font-size: 13px;
+      font-size: 12.5px;
       font-weight: 600;
       fill: #475569;
-      text-anchor: middle;
+      text-anchor: start;
     }
   </style>
 
-  <rect x="0" y="0" width="2300" height="900" fill="#ffffff"/>
+  <rect x="0" y="0" width="2360" height="980" fill="#ffffff"/>
 
-  <rect class="group group-workload" x="40" y="80" width="250" height="170" rx="18" ry="18"/>
-  <text class="group-title" x="165" y="120">Workload</text>
-  <rect class="box" x="90" y="145" width="150" height="72" rx="12" ry="12"/>
-  <text class="box-title" x="165" y="174">Pod spec</text>
-  <text class="box-body" x="165" y="198">limits: example.com/gpu=1</text>
+  <rect class="group group-workload" x="40" y="120" width="260" height="180" rx="18" ry="18"/>
+  <text class="group-title" x="170" y="160">Workload</text>
+  <rect class="box" x="95" y="190" width="170" height="84" rx="12" ry="12"/>
+  <text class="box-title" x="180" y="222">Pod spec</text>
+  <text class="box-body" x="180" y="244">
+    <tspan x="180" dy="0">limits:</tspan>
+    <tspan x="180" dy="16">example.com/gpu = 1</tspan>
+  </text>
 
-  <rect class="group group-api" x="340" y="40" width="650" height="400" rx="18" ry="18"/>
-  <text class="group-title" x="665" y="80">API Server + etcd</text>
-  <rect class="box" x="390" y="100" width="220" height="76" rx="12" ry="12"/>
-  <text class="box-title" x="500" y="129">DeviceClass</text>
-  <text class="box-body" x="500" y="152">extendedResourceName mapping</text>
-  <rect class="box" x="390" y="205" width="220" height="76" rx="12" ry="12"/>
-  <text class="box-title" x="500" y="234">ResourceSlice</text>
-  <text class="box-body" x="500" y="257">DRA device inventory per node</text>
-  <rect class="box" x="680" y="100" width="250" height="76" rx="12" ry="12"/>
-  <text class="box-title" x="805" y="129">Node.status.capacity</text>
-  <text class="box-body" x="805" y="152">(device plugin path)</text>
-  <rect class="box" x="680" y="205" width="250" height="76" rx="12" ry="12"/>
-  <text class="box-title" x="805" y="234">Special ResourceClaim</text>
-  <text class="box-body" x="805" y="257">(created by scheduler)</text>
-  <rect class="box" x="470" y="315" width="390" height="88" rx="12" ry="12"/>
-  <text class="box-title" x="665" y="345">Pod.status.extendedResourceClaimStatus</text>
-  <text class="box-body" x="665" y="368">container/resource -&gt; requestName</text>
+  <rect class="group group-api" x="340" y="50" width="720" height="450" rx="18" ry="18"/>
+  <text class="group-title" x="700" y="92">API Server + etcd</text>
+  <rect class="box" x="390" y="125" width="240" height="82" rx="12" ry="12"/>
+  <text class="box-title" x="510" y="154">DeviceClass</text>
+  <text class="box-body" x="510" y="180">extendedResourceName mapping</text>
+  <rect class="box" x="390" y="235" width="240" height="82" rx="12" ry="12"/>
+  <text class="box-title" x="510" y="264">ResourceSlice</text>
+  <text class="box-body" x="510" y="290">DRA device inventory per node</text>
+  <rect class="box" x="735" y="125" width="275" height="82" rx="12" ry="12"/>
+  <text class="box-title" x="872.5" y="154">Node.status.capacity</text>
+  <text class="box-body" x="872.5" y="180">(device plugin path)</text>
+  <rect class="box" x="735" y="235" width="275" height="82" rx="12" ry="12"/>
+  <text class="box-title" x="872.5" y="264">Special ResourceClaim</text>
+  <text class="box-body" x="872.5" y="290">(created by scheduler)</text>
+  <rect class="box" x="480" y="355" width="440" height="98" rx="12" ry="12"/>
+  <text class="box-title-small" x="700" y="387">Pod.status.extendedResourceClaimStatus</text>
+  <text class="box-body" x="700" y="415">container/resource -&gt; requestName</text>
 
-  <rect class="group group-scheduler" x="1040" y="110" width="350" height="340" rx="18" ry="18"/>
-  <text class="group-title" x="1215" y="150">kube-scheduler</text>
-  <rect class="box" x="1090" y="175" width="250" height="74" rx="12" ry="12"/>
-  <text class="box-title" x="1215" y="204">NodeResourcesFit</text>
-  <text class="box-body" x="1215" y="227">ScalarResources + DynamicResources</text>
-  <rect class="box" x="1090" y="275" width="250" height="74" rx="12" ry="12"/>
-  <text class="box-title" x="1215" y="304">dynamicresources plugin</text>
-  <text class="box-body" x="1215" y="327">PreFilter -&gt; Filter -&gt; Reserve -&gt; PreBind</text>
-  <rect class="box" x="1090" y="375" width="250" height="74" rx="12" ry="12"/>
-  <text class="box-title" x="1215" y="404">DRA allocator</text>
-  <text class="box-body" x="1215" y="427">build DeviceRequests + pick devices</text>
+  <rect class="group group-scheduler" x="1100" y="160" width="360" height="390" rx="18" ry="18"/>
+  <text class="group-title" x="1280" y="200">kube-scheduler</text>
+  <rect class="box" x="1180" y="225" width="250" height="78" rx="12" ry="12"/>
+  <text class="box-title" x="1305" y="254">NodeResourcesFit</text>
+  <text class="box-body" x="1305" y="279">ScalarResources + DynamicResources</text>
+  <rect class="box" x="1180" y="330" width="250" height="86" rx="12" ry="12"/>
+  <text class="box-title" x="1305" y="358">dynamicresources plugin</text>
+  <text class="box-body" x="1305" y="380">
+    <tspan x="1305" dy="0">PreFilter -&gt; Filter</tspan>
+    <tspan x="1305" dy="16">Reserve -&gt; PreBind</tspan>
+  </text>
+  <rect class="box" x="1180" y="438" width="250" height="86" rx="12" ry="12"/>
+  <text class="box-title" x="1305" y="466">DRA allocator</text>
+  <text class="box-body" x="1305" y="488">build DeviceRequests + pick devices</text>
 
-  <rect class="group group-node-a" x="1470" y="40" width="770" height="390" rx="18" ry="18"/>
-  <text class="group-title" x="1855" y="78">Node A</text>
-  <text class="group-subtitle" x="1855" y="103">(DRA-backed extended resource)</text>
-  <rect class="box" x="1510" y="225" width="120" height="74" rx="12" ry="12"/>
-  <text class="box-title" x="1570" y="254">kubelet</text>
-  <text class="box-body" x="1570" y="277">DRA manager</text>
-  <rect class="box" x="1650" y="225" width="180" height="74" rx="12" ry="12"/>
-  <text class="box-title" x="1740" y="254">DRA Driver</text>
-  <text class="box-body" x="1740" y="277">PrepareResources</text>
-  <rect class="box" x="1850" y="225" width="110" height="74" rx="12" ry="12"/>
-  <text class="box-title" x="1905" y="262">CDI</text>
-  <rect class="box" x="1980" y="225" width="110" height="74" rx="12" ry="12"/>
-  <text class="box-title" x="2035" y="254">Container</text>
-  <text class="box-body" x="2035" y="277">Runtime</text>
-  <rect class="box" x="2110" y="225" width="90" height="74" rx="12" ry="12"/>
-  <text class="box-title" x="2155" y="262">Containers</text>
+  <rect class="group group-node-a" x="1540" y="75" width="760" height="350" rx="18" ry="18"/>
+  <text class="group-title" x="1920" y="115">Node A</text>
+  <text class="group-subtitle" x="1920" y="140">(DRA-backed extended resource)</text>
+  <rect class="label-bg" x="1572" y="186" width="182" height="46" rx="10" ry="10"/>
+  <text class="edge-label" x="1588" y="205">
+    <tspan x="1588" dy="0">if node uses</tspan>
+    <tspan x="1588" dy="15">device plugin capacity</tspan>
+  </text>
+  <rect class="box" x="1560" y="243" width="125" height="78" rx="12" ry="12"/>
+  <text class="box-title" x="1622.5" y="270">kubelet</text>
+  <text class="box-body" x="1622.5" y="294">DRA manager</text>
+  <rect class="box" x="1710" y="243" width="175" height="78" rx="12" ry="12"/>
+  <text class="box-title" x="1797.5" y="270">DRA Driver</text>
+  <text class="box-body" x="1797.5" y="294">PrepareResources</text>
+  <rect class="box" x="1910" y="243" width="110" height="78" rx="12" ry="12"/>
+  <text class="box-title" x="1965" y="282">CDI</text>
+  <rect class="box" x="2045" y="243" width="115" height="78" rx="12" ry="12"/>
+  <text class="box-title" x="2102.5" y="270">Container</text>
+  <text class="box-body" x="2102.5" y="294">Runtime</text>
+  <rect class="box" x="2185" y="243" width="90" height="78" rx="12" ry="12"/>
+  <text class="box-title" x="2230" y="282">Containers</text>
 
-  <rect class="group group-node-b" x="1470" y="500" width="770" height="160" rx="18" ry="18"/>
-  <text class="group-title" x="1855" y="540">Node B (legacy device plugin)</text>
-  <rect class="box" x="1760" y="560" width="190" height="74" rx="12" ry="12"/>
-  <text class="box-title" x="1855" y="599">Device Plugin</text>
+  <rect class="group group-node-b" x="1540" y="560" width="760" height="180" rx="18" ry="18"/>
+  <text class="group-title" x="1920" y="600">Node B (legacy device plugin)</text>
+  <rect class="box" x="1840" y="624" width="160" height="78" rx="12" ry="12"/>
+  <text class="box-title" x="1920" y="663">Device Plugin</text>
 
-  <rect class="note" x="700" y="580" width="560" height="116" rx="16" ry="16"/>
-  <text class="box-title" x="980" y="614">Constraint:</text>
-  <text class="box-body" x="980" y="639">One node cannot expose the same resource name</text>
-  <text class="box-body" x="980" y="661">from both DRA and Device Plugin.</text>
+  <rect class="note" x="700" y="620" width="640" height="120" rx="16" ry="16"/>
+  <text class="box-title" x="1020" y="656">Constraint:</text>
+  <text class="box-body" x="1020" y="683">One node cannot expose the same resource name</text>
+  <text class="box-body" x="1020" y="704">from both DRA and Device Plugin.</text>
 
-  <path class="flow" d="M 240 181 L 300 181 L 300 460 L 1060 460 L 1060 212 L 1090 212"/>
-  <path class="flow" d="M 610 138 L 660 138 L 660 212 L 1090 212"/>
-  <path class="flow" d="M 610 243 L 700 243 L 700 212 L 1090 212"/>
-  <path class="flow" d="M 930 138 L 970 138 L 970 212 L 1090 212"/>
+  <path class="flow" d="M 265 232 L 320 232 L 320 560 L 1140 560 L 1140 264 L 1180 264"/>
+  <path class="flow" d="M 630 166 L 680 166 L 680 105 L 1075 105 L 1075 246 L 1180 246"/>
+  <path class="flow" d="M 630 276 L 680 276 L 680 336 L 1095 336 L 1095 264 L 1180 264"/>
+  <path class="flow" d="M 1010 166 L 1110 166 L 1110 282 L 1180 282"/>
 
-  <path class="flow" d="M 1215 249 L 1215 275"/>
-  <path class="flow" d="M 1215 349 L 1215 375"/>
-  <path class="flow" d="M 1090 412 L 1010 412 L 1010 243 L 930 243"/>
-  <path class="flow" d="M 1090 312 L 1020 312 L 1020 359 L 860 359"/>
+  <path class="flow" d="M 1305 303 L 1305 330"/>
+  <path class="flow" d="M 1305 416 L 1305 438"/>
+  <path class="flow" d="M 1180 481 L 1125 481 L 1125 276 L 1010 276"/>
+  <path class="flow" d="M 1180 373 L 1130 373 L 1130 404 L 920 404"/>
 
-  <path class="flow" d="M 860 359 L 950 359 L 950 470 L 1430 470 L 1430 262 L 1510 262"/>
-  <path class="flow" d="M 930 243 L 1000 243 L 1000 90 L 1430 90 L 1430 262 L 1510 262"/>
-  <path class="flow" d="M 1630 262 L 1650 262"/>
-  <path class="flow" d="M 1830 262 L 1850 262"/>
-  <path class="flow" d="M 1960 262 L 1980 262"/>
-  <path class="flow" d="M 2090 262 L 2110 262"/>
+  <path class="flow" d="M 920 404 L 1000 404 L 1000 570 L 1510 570 L 1510 282 L 1560 282"/>
+  <path class="flow" d="M 1010 276 L 1080 276 L 1080 145 L 1510 145 L 1510 262 L 1560 262"/>
+  <path class="flow" d="M 1685 282 L 1710 282"/>
+  <path class="flow" d="M 1885 282 L 1910 282"/>
+  <path class="flow" d="M 2020 282 L 2045 282"/>
+  <path class="flow" d="M 2160 282 L 2185 282"/>
 
-  <path class="flow-muted" d="M 1340 212 L 1420 212 L 1420 597 L 1760 597"/>
-  <text class="edge-label" x="1590" y="240">if node uses device plugin capacity</text>
+  <path class="flow-muted" d="M 1430 264 L 1495 264 L 1495 663 L 1840 663"/>
 
-  <path class="note-link" d="M 1260 616 L 1410 616 L 1410 240 L 1470 240"/>
-  <path class="note-link" d="M 1260 660 L 1410 660 L 1410 580 L 1470 580"/>
+  <path class="note-link" d="M 1340 676 L 1498 676 L 1498 248 L 1540 248"/>
+  <path class="note-link" d="M 1340 712 L 1498 712 L 1498 650 L 1540 650"/>
 </svg>

--- a/docs/kubernetes/dra.md
+++ b/docs/kubernetes/dra.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-04-22
+last_updated: 2026-04-27
 tags: kubernetes, dra, resource-allocation, device-management, topology
 canonical_path: docs/kubernetes/dra.md
 ---
@@ -239,6 +239,13 @@ device (for example different subnets or fault domains).
 
 Many organizations have significant investments in Device Plugin-based
 solutions. Migrating to DRA presents challenges:
+
+Compatibility flow for DRA-backed extended resources:
+
+![DRA-backed extended resource flow](../../diagrams/dra-extended-resource-flow.svg)
+
+Editable source:
+[dra-extended-resource-flow.mmd](../../diagrams/dra-extended-resource-flow.mmd)
 
 **Coexistence Problems:**
 


### PR DESCRIPTION
## What changed
- add a DRA-backed extended resource flow diagram as a reusable SVG asset
- add the editable Mermaid source for the same diagram
- reference the diagram from the DRA migration section in `docs/kubernetes/dra.md`

## Why
The DRA migration section discussed coexistence with device plugins, but it did not include a visual explanation of how extended resource requests map into the DRA-backed scheduling and kubelet flow.

## Impact
- readers can understand the DRA extended resource compatibility path faster
- future edits can be made against the Mermaid source instead of redrawing the diagram

## Validation
- `xmllint --noout diagrams/dra-extended-resource-flow.svg`
- `git diff --check --cached`
