### PR TITLE
[codex] docs: add model distribution stack diagram

### DIFF
--- a/docs/blog/2026-04-28/2026-04-28-understanding-model-distribution-stack_zh.md
+++ b/docs/blog/2026-04-28/2026-04-28-understanding-model-distribution-stack_zh.md
@@ -32,33 +32,49 @@ canonical_path: docs/blog/2026-04-28/2026-04-28-understanding-model-distribution
 ## 总体架构图
 
 ```mermaid
-flowchart LR
-  subgraph P["1. 模型提供方 / 模型仓"]
-    DEV["模型提供方 / 微调团队"]
-    subgraph NET["互联网"]
+flowchart TB
+  classDef oci fill:#e8f3ff,stroke:#2b6cb0,color:#0f172a;
+  classDef model fill:#fff1e6,stroke:#c2410c,color:#111827;
+  classDef runtime fill:#ecfdf5,stroke:#047857,color:#111827;
+  classDef neutral fill:#f8fafc,stroke:#64748b,color:#111827;
+
+  subgraph S["1. 提供方 / 服务端视角"]
+    direction LR
+
+    subgraph OCI_LANE["Docker image / OCI artifact lane"]
+      direction TB
+      DH["Docker Hub<br/>公共镜像仓库"]
+      HB["Harbor<br/>local Docker Hub / distribution<br/>私有 OCI Registry"]
+      DH -->|"同步 / 复制 / 私有镜像管理"| HB
+    end
+
+    subgraph MODEL_LANE["Model distribution lane"]
+      direction TB
       HF["Hugging Face<br/>公共模型 Hub"]
       MS["ModelScope<br/>公共模型 / 数据 / API 平台"]
-    end
-    subgraph IDC["企业数据中心 / 私有环境"]
-      PHF["私有 Hugging Face<br/>目标能力"]
-      MX["MatrixHub<br/>HF-compatible 私有模型 Hub"]
-      MP["ModelPack<br/>OCI 模型打包"]
-      HB["Harbor<br/>私有 OCI Registry"]
+      MX["MatrixHub<br/>private Hugging Face<br/>HF-compatible 私有模型 Hub"]
+      MP["ModelPack<br/>把模型打包为 OCI artifact"]
+      HF -->|"镜像 / 缓存"| MX
+      MS -. "公共来源之一" .-> MX
+      MP -->|"模型进入 OCI 生态"| HB
     end
   end
 
-  subgraph A["2. 模型获取 / 下载方式"]
-    PULL["HF-compatible 拉取<br/>SDK / CLI / API"]
-    DF["Dragonfly<br/>node 级 P2P<br/>seed peer + scheduler"]
+  subgraph C["2. Client / 下载获取视角"]
+    direction LR
+    PULL["HF-compatible SDK / CLI / API"]
+    DF["Dragonfly<br/>node 级 P2P<br/>image / artifact / model files"]
   end
 
-  subgraph R["3. 最终使用者 / 运行时"]
-    USER["最终使用者 / 业务应用"]
+  subgraph U["3. 最终使用者 / 运行时视角"]
+    direction LR
+    APP["最终用户 / 业务应用"]
     SVC["推理服务<br/>vLLM / SGLang / Dynamo"]
-    ME["ModelExpress<br/>运行时权重 P2P"]
+    ME["ModelExpress<br/>GPU worker 权重 P2P"]
 
     subgraph N1["Node 1"]
-      F1["本地模型缓存 / 文件"]
+      direction TB
+      F1["本地镜像 / 模型文件缓存"]
       subgraph G1["GPU workers"]
         W11["GPU 0 worker"]
         W12["GPU 1 worker"]
@@ -66,22 +82,14 @@ flowchart LR
     end
 
     subgraph N2["Node 2"]
-      F2["本地模型缓存 / 文件"]
+      direction TB
+      F2["本地镜像 / 模型文件缓存"]
       subgraph G2["GPU workers"]
         W21["GPU 0 worker"]
         W22["GPU 1 worker"]
       end
     end
   end
-
-  DEV -->|"发布 / 同步"| HF
-  DEV -->|"发布 / 同步"| MS
-  DEV -->|"私有上传"| MX
-  DEV -->|"打包模型"| MP
-
-  PHF -. "可由此实现" .-> MX
-  MP --> HB
-  HF -->|"镜像 / 缓存"| MX
 
   MX -->|"HF-compatible endpoint"| PULL
   HF -->|"hf://"| DF
@@ -92,32 +100,42 @@ flowchart LR
   PULL --> F2
   DF --> F1
   DF --> F2
-  F1 <-->|"node 级 P2P 文件分片"| F2
+  F1 <-->|"Dragonfly: node 级文件分片 P2P"| F2
 
   F1 --> W11
   F1 --> W12
   F2 --> W21
   F2 --> W22
 
-  USER --> SVC
+  APP --> SVC
   SVC --> W11
   SVC --> W21
 
-  ME -. "权重复用" .-> W11
-  ME -. "权重复用" .-> W12
-  ME -. "权重复用" .-> W21
-  ME -. "权重复用" .-> W22
+  ME -. "权重复用 / 热副本传播" .-> W11
+  ME -. "权重复用 / 热副本传播" .-> W12
+  ME -. "权重复用 / 热副本传播" .-> W21
+  ME -. "权重复用 / 热副本传播" .-> W22
 
   W11 <-->|"同节点 GPU / NVLink"| W12
   W12 <-->|"跨节点 RDMA / UCX / NIXL"| W21
   W21 <-->|"同节点 GPU / NVLink"| W22
+
+  class DH,HB oci;
+  class HF,MS,MX,MP,PULL model;
+  class DF,F1,F2 neutral;
+  class APP,SVC,ME,W11,W12,W21,W22 runtime;
+
+  style OCI_LANE fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
+  style MODEL_LANE fill:#fff1e6,stroke:#c2410c,stroke-width:2px
+  style N1 fill:#f0fdf4,stroke:#16a34a,stroke-width:1px
+  style N2 fill:#f0fdf4,stroke:#16a34a,stroke-width:1px
 ```
 
 这张图可以从三个视角来读：
 
-- **模型提供方视角**：左侧是模型来源。Hugging Face 和 ModelScope 位于互联网侧，MatrixHub 和 Harbor 更适合放在企业数据中心内部。
-- **模型获取视角**：中间是下载路径。MatrixHub 更像 HF-compatible 的私有入口，Dragonfly 则是 node 级别的 P2P 文件分发层。
-- **最终使用者视角**：右侧是运行时。最终用户请求进入推理服务，模型文件先进入节点本地缓存，再由 GPU worker 消费；ModelExpress 则进一步处理 worker 之间、甚至跨 node GPU 之间的权重共享与冷启动优化。
+- **提供方 / 服务端视角**：蓝色背景代表 `Docker image / OCI artifact` 路线，Harbor 在这里更像企业内部的 `local Docker Hub / distribution`；橙色背景代表 `model distribution` 路线，Hugging Face、ModelScope 和 MatrixHub 都属于这一侧。
+- **下载获取视角**：MatrixHub 提供 HF-compatible 拉取入口；Dragonfly 负责 node 级文件分发，它既可以接 Harbor 的 OCI pull，也可以接 `hf://` 与 `modelscope://` 这类模型来源。
+- **最终使用者视角**：模型文件先进入 node 本地缓存，再进入 GPU worker；`ModelExpress` 则位于更靠后的运行时层，处理同 node 甚至跨 node GPU 之间的权重共享与冷启动优化。
 
 理解这一点之后，很多争论都会自然消失：这些项目大多不是彼此替代，而是站在不同层上解不同的问题。
 
@@ -216,6 +234,10 @@ Harbor 是一个成熟的私有 OCI Registry。它擅长的是：
 - 复制
 - 保留策略
 - 统一管理 OCI artifact
+
+如果要用一句更容易代入的话来理解它，可以把 Harbor 看作：
+
+**企业内部增强版的 Docker Hub / distribution。**
 
 所以 Harbor 解决的不是“原生 HF-compatible 入口”，而是：
 

--- a/docs/blog/2026-04-28/2026-04-28-understanding-model-distribution-stack_zh.md
+++ b/docs/blog/2026-04-28/2026-04-28-understanding-model-distribution-stack_zh.md
@@ -1,0 +1,408 @@
+---
+status: Active
+maintainer: pacoxu
+last_updated: 2026-04-28
+tags: blog, ai-infrastructure, inference, huggingface, registry, model-distribution
+canonical_path: docs/blog/2026-04-28/2026-04-28-understanding-model-distribution-stack_zh.md
+---
+
+# 如何理解 Hugging Face、私有 Hugging Face、MatrixHub、Harbor + Dragonfly + ModelPack 与 ModelExpress
+
+在讨论 AI 模型分发时，团队很容易把几类完全不同的系统混在一起：有些项目解决的是
+**模型从哪里来**，有些解决的是 **模型在企业内部怎么托管和治理**，还有一些解决的是
+**模型如何更快进入 GPU 集群并完成冷启动**。
+
+这也是很多技术讨论容易“错位”的原因。一个人讲的是公共模型平台，另一个人讲的是
+私有仓库，第三个人讲的是运行时权重传输，但所有人都在说“模型分发”。
+
+本文尝试把下面这些常见名词放进同一张图里：
+
+- Hugging Face
+- ModelScope
+- 私有 Hugging Face
+- MatrixHub
+- Harbor + Dragonfly + ModelPack
+- ModelExpress
+
+重点不是做简单产品介绍，而是回答两个更重要的问题：
+
+1. 它们分别在模型分发链路里的哪一层？
+2. 它们分别想解决什么问题，适合什么场景？
+
+## 总体架构图
+
+```mermaid
+flowchart LR
+  U["模型消费者<br/>训练 / 评测 / vLLM / SGLang / Dynamo"]
+
+  HF["Hugging Face<br/>公共模型 Hub"]
+  MS["ModelScope<br/>公共模型 / 数据 / API 平台"]
+
+  PHF["私有 Hugging Face<br/>目标能力"]
+  MX["MatrixHub<br/>HF-compatible 私有模型 Hub"]
+
+  MP["ModelPack<br/>OCI 模型打包 / 规范"]
+  HB["Harbor<br/>私有 OCI Registry"]
+  DF["Dragonfly<br/>P2P 分发加速"]
+
+  CL["Inference / Kubernetes Cluster"]
+  ME["ModelExpress<br/>运行时权重传输 / 冷启动加速"]
+
+  U -->|"HF / SDK / API"| HF
+  U -->|"SDK / API"| MS
+
+  PHF -. "可由此实现" .-> MX
+  U -->|"HF-compatible endpoint"| MX
+  HF -->|"首次拉取 / 缓存 / 同步"| MX
+
+  HF -->|"打包为 OCI artifact"| MP
+  MS -->|"打包为 OCI artifact"| MP
+  MP --> HB
+  HB --> DF
+  DF -->|"节点级 P2P 下载 / 预热"| CL
+
+  MX -->|"私有模型源 / 治理入口"| CL
+  CL --> ME
+  ME -->|"worker-to-worker / GPU-to-GPU"| CL
+
+  MX -. "可组合" .-> ME
+  DF -. "解决文件分发" .-> ME
+```
+
+这张图的阅读方式很简单：
+
+- **最左侧**是公共模型来源和开发者默认入口
+- **中间**是企业内部的私有模型入口或制品治理体系
+- **右侧**是集群内的节点分发和运行时加速
+
+理解这一点之后，很多争论都会自然消失：这些项目大多不是彼此替代，而是站在不同层上解不同的问题。
+
+## 一、Hugging Face 与 ModelScope：它们首先是“公共模型来源”
+
+### Hugging Face
+
+Hugging Face 是今天最主流的公共模型 Hub。大量训练、评测和推理工作流默认围绕
+`huggingface_hub`、`transformers` 以及各种兼容客户端构建。
+
+它最大的价值是：
+
+- 公共模型发现与共享
+- 社区驱动的模型生态
+- 对研究和开发工作流非常友好
+
+但它并不是为企业内部大规模模型分发而设计的。尤其是在下面这些场景里，问题会迅速放大：
+
+- 大模型需要分发到几十到几百个节点
+- 集群会频繁扩缩容
+- 企业需要私有权限、审计和内网隔离
+- 同一个模型被反复拉取和重复传输
+
+### ModelScope
+
+ModelScope 在这个框架里，最接近的角色不是 MatrixHub，也不是 ModelExpress，而是
+**另一类公共模型生态和平台入口**。
+
+它和 Hugging Face 有相似的一面：
+
+- 公共模型 Hub
+- 数据集 Hub
+- SDK / CLI / 下载能力
+
+它又比传统意义上的公共模型仓库更平台化一些，因为它还强调：
+
+- 在线体验与 Notebook / Studio 能力
+- API-Inference
+- 更偏中文和国内生态的模型覆盖
+
+所以从模型分发链路上说，Hugging Face 和 ModelScope 首先解决的是：
+
+**模型从哪里来，开发者如何访问公共模型生态。**
+
+它们不是企业内部治理层，也不是集群内冷启动优化层。
+
+## 二、私有 Hugging Face：这是“目标能力”，不是单一产品
+
+很多团队说“我们想做一个私有 Hugging Face”，本质上表达的通常不是“想复制一遍
+Hugging Face 网站”，而是想获得这样一组能力：
+
+- 私有模型托管
+- 权限控制与审计
+- 内网 / air-gapped 环境可用
+- 研发侧尽量不改现有 HF 工作流
+- 模型能稳定、高效地分发到训练和推理环境
+
+也就是说，**私有 Hugging Face 更像一个目标状态**。
+
+不同团队会用不同方案去逼近这个状态：
+
+- 有的会选择 `MatrixHub`
+- 有的会选择 `Harbor + ModelPack + Dragonfly`
+- 还有的会自己在通用存储或制品仓库前面封装一层兼容入口
+
+但这些方案能提供的“兼容程度”和“运维复杂度”并不相同。
+
+## 三、MatrixHub：更像“私有 Hugging Face”
+
+如果你想在这些方案里找到一个最贴近“私有 Hugging Face”概念的项目，答案基本就是
+`MatrixHub`。
+
+它想解决的问题非常明确：
+
+- 让企业内部拥有一个私有模型 Hub
+- 尽量保留 Hugging Face 风格的访问体验
+- 提供私有模型治理、缓存、同步和 air-gapped 支持
+
+因此，MatrixHub 更适合下面这些场景：
+
+- 现有训练、评测、推理代码大量依赖 HF 工作流
+- 希望通过 `HF_ENDPOINT` 一类方式平滑切换
+- 企业有模型权限、合规和多区域同步需求
+- 想快速得到一个“面向模型团队”的私有入口
+
+它的核心定位不是“通用制品仓库”，而是 **AI model hub**。这和 Harbor 的思路有明显差异。
+
+## 四、Harbor + ModelPack + Dragonfly：这是一条 OCI-first 的企业分发栈
+
+### 1. Harbor 解决什么问题
+
+Harbor 是一个成熟的私有 OCI Registry。它擅长的是：
+
+- RBAC
+- 签名与验证
+- 复制
+- 保留策略
+- 统一管理 OCI artifact
+
+所以 Harbor 解决的不是“原生 HF-compatible 入口”，而是：
+
+**企业内部如何以标准化方式托管和治理模型制品。**
+
+### 2. ModelPack 解决什么问题
+
+ModelPack 处在更前面一层，它是 **模型如何被封装为 OCI artifact** 的规范/打包路径。
+
+它不解决：
+
+- GPU-to-GPU
+- 冷启动优化
+- 集群内权重传输
+
+它解决的是：
+
+- 模型如何被标准化描述和打包
+- 模型如何进入 OCI 生态
+
+因此，ModelPack 更接近“包装和格式”层，而不是“传输和运行时”层。
+
+### 3. Dragonfly 解决什么问题
+
+Dragonfly 是这一条栈里最容易被低估的组件。它解决的是：
+
+**同一个模型文件如何被高效分发到大量节点。**
+
+在 AI 模型场景中，它的价值尤其明显，因为：
+
+- 模型文件往往是 10 GB 到 100+ GB 级别
+- 同一个版本会被几十到几百个节点重复拉取
+- 源站经常受限于带宽、速率限制和出口成本
+
+Dragonfly 的 P2P 更准确地说是：
+
+- **仓库到节点的文件级 P2P**
+- **piece/chunk 级传播**
+- **Seed Peer 回源一次，其他节点通过 peer 网格传播**
+
+随着 `hf://` 和 `modelscope://` 的原生支持，它已经不仅能做通用文件和 OCI artifact 分发，也能直接把 Hugging Face 和 ModelScope 当作上游模型来源。
+
+### 4. 这条栈适合谁
+
+`Harbor + ModelPack + Dragonfly` 特别适合：
+
+- 企业已经是 OCI-first / Kubernetes-first
+- 平台团队更看重标准化制品治理
+- 可以接受模型工作流围绕 OCI artifact 来组织
+- 不强求原生 Hugging Face 客户端语义
+
+这是一条非常工程化、平台化的路径，但它不是“私有 Hugging Face 体验优先”的路径。
+
+## 五、ModelExpress：它不解决“模型仓库”，而解决“运行时最后一跳”
+
+ModelExpress 与前面几类项目最大的区别在于，它不是模型 Hub，也不是通用 registry，也不是单纯的节点分发层。
+
+它真正瞄准的问题是：
+
+**模型已经进入集群之后，如何更快地把权重送进新的推理副本和 GPU。**
+
+这通常发生在下面这些场景：
+
+- vLLM / Dynamo / TRT-LLM 等推理系统扩容
+- 新 pod 启动时不想重新完整走一遍磁盘读取与权重加载
+- 一个副本已经加载好的模型，希望其他副本复用其“热状态”
+
+因此，ModelExpress 的 P2P 与 Dragonfly 的 P2P 不是一回事。
+
+### Dragonfly 的 P2P
+
+- 传的是模型文件
+- 路径是 `源站 / 仓库 -> 节点`
+- 目标是减少重复下载和源站压力
+
+### ModelExpress 的 P2P
+
+- 传的是运行时权重
+- 路径是 `seed worker / source GPU -> target worker / target GPU`
+- 目标是减少冷启动、磁盘读取和重复加载
+
+从硬件视角看，ModelExpress 更依赖：
+
+- InfiniBand / RoCE
+- UCX
+- RDMA
+- NVLink / NVSwitch
+- GPU-to-GPU 通信能力
+
+所以它最自然的落点是：
+
+- **集群内**
+- **多节点 GPU 推理场景**
+- **大模型副本扩容**
+- **对冷启动时间非常敏感的系统**
+
+它不是一个多集群统一模型仓库，也不是公共模型来源。
+
+## 六、这些项目分别在尝试解决什么问题
+
+如果把问题拆开，每个项目的目标会清楚很多。
+
+### 1. “模型从哪里来？”
+
+解决这个问题的是：
+
+- Hugging Face
+- ModelScope
+
+它们提供公共模型来源、社区和开发者入口。
+
+### 2. “企业内部如何托管与治理模型？”
+
+解决这个问题的是：
+
+- MatrixHub
+- Harbor
+
+两者的区别是：
+
+- MatrixHub 更偏 **私有 Hugging Face**
+- Harbor 更偏 **私有 OCI 制品底座**
+
+### 3. “模型如何标准化打包并进入 OCI 生态？”
+
+解决这个问题的是：
+
+- ModelPack
+
+### 4. “同一个模型如何高效分发到大量节点？”
+
+解决这个问题的是：
+
+- Dragonfly
+
+### 5. “模型进入集群后，如何更快变成可服务的 GPU 副本？”
+
+解决这个问题的是：
+
+- ModelExpress
+
+## 七、典型场景怎么选
+
+### 场景 A：研发团队以 Hugging Face 工作流为中心
+
+如果你的团队大量依赖：
+
+- `huggingface_hub`
+- `transformers`
+- HF 风格的模型组织方式
+
+而你的目标是最小改动切入企业私有模型分发，那么优先看：
+
+- `MatrixHub`
+
+如果后续还要进一步优化推理冷启动，再叠加：
+
+- `ModelExpress`
+
+### 场景 B：平台团队以 OCI artifact 和 Kubernetes 为中心
+
+如果平台团队已经在做：
+
+- Harbor
+- OCI Registry
+- Kubernetes 制品治理
+- 镜像签名、复制、保留、审计
+
+那么更自然的路径是：
+
+- `ModelPack + Harbor + Dragonfly`
+
+这条路的关键不是模拟 HF 体验，而是把模型纳入统一制品体系。
+
+### 场景 C：大规模 GPU 集群频繁扩缩容
+
+如果真正痛点是：
+
+- 模型太大
+- 节点太多
+- 扩容时每个副本重新加载太慢
+
+那就要区分两个阶段：
+
+- **模型文件到节点**：`Dragonfly`
+- **权重到 worker / GPU**：`ModelExpress`
+
+两者可以叠加，不冲突。
+
+### 场景 D：多来源模型生态
+
+如果企业同时从下面这些地方拿模型：
+
+- Hugging Face
+- ModelScope
+- 内部自研模型
+
+那么更推荐做分层设计：
+
+- 上游公共来源：`Hugging Face / ModelScope`
+- 企业内部治理：`MatrixHub` 或 `Harbor`
+- 节点级分发：`Dragonfly`
+- 运行时加速：`ModelExpress`
+
+## 八、一个更实用的结论
+
+这些系统真正的差别，不在于“谁更强”，而在于它们分别假设你卡在不同的位置。
+
+- Hugging Face / ModelScope 假设你需要的是 **公共模型入口**
+- MatrixHub 假设你需要的是 **私有模型 Hub**
+- Harbor + ModelPack 假设你需要的是 **标准化制品治理**
+- Dragonfly 假设你需要的是 **节点级大规模分发**
+- ModelExpress 假设你需要的是 **运行时权重加速和 GPU 冷启动优化**
+
+因此，最应该避免的不是“选错单个项目”，而是**把不同层的问题交给错误的组件**。
+
+把它们放在一张图里之后，一个更准确的心智模型应该是：
+
+- `Hugging Face / ModelScope` 是上游来源
+- `MatrixHub` 是私有 HF 路线
+- `Harbor + ModelPack + Dragonfly` 是 OCI-first 路线
+- `ModelExpress` 是集群内最后一跳运行时路线
+
+很多时候，答案不是二选一，而是**分层组合**。
+
+## 参考链接
+
+- [Hugging Face](https://huggingface.co/)
+- [ModelScope](https://modelscope.cn/)
+- [MatrixHub](https://github.com/matrixhub-ai/matrixhub)
+- [Harbor](https://goharbor.io/)
+- [Dragonfly](https://d7y.io/)
+- [ModelPack](https://modelpack.org/)
+- [ModelExpress](https://github.com/ai-dynamo/modelexpress)

--- a/docs/blog/2026-04-28/2026-04-28-understanding-model-distribution-stack_zh.md
+++ b/docs/blog/2026-04-28/2026-04-28-understanding-model-distribution-stack_zh.md
@@ -33,47 +33,91 @@ canonical_path: docs/blog/2026-04-28/2026-04-28-understanding-model-distribution
 
 ```mermaid
 flowchart LR
-  U["模型消费者<br/>训练 / 评测 / vLLM / SGLang / Dynamo"]
+  subgraph P["1. 模型提供方 / 模型仓"]
+    DEV["模型提供方 / 微调团队"]
+    subgraph NET["互联网"]
+      HF["Hugging Face<br/>公共模型 Hub"]
+      MS["ModelScope<br/>公共模型 / 数据 / API 平台"]
+    end
+    subgraph IDC["企业数据中心 / 私有环境"]
+      PHF["私有 Hugging Face<br/>目标能力"]
+      MX["MatrixHub<br/>HF-compatible 私有模型 Hub"]
+      MP["ModelPack<br/>OCI 模型打包"]
+      HB["Harbor<br/>私有 OCI Registry"]
+    end
+  end
 
-  HF["Hugging Face<br/>公共模型 Hub"]
-  MS["ModelScope<br/>公共模型 / 数据 / API 平台"]
+  subgraph A["2. 模型获取 / 下载方式"]
+    PULL["HF-compatible 拉取<br/>SDK / CLI / API"]
+    DF["Dragonfly<br/>node 级 P2P<br/>seed peer + scheduler"]
+  end
 
-  PHF["私有 Hugging Face<br/>目标能力"]
-  MX["MatrixHub<br/>HF-compatible 私有模型 Hub"]
+  subgraph R["3. 最终使用者 / 运行时"]
+    USER["最终使用者 / 业务应用"]
+    SVC["推理服务<br/>vLLM / SGLang / Dynamo"]
+    ME["ModelExpress<br/>运行时权重 P2P"]
 
-  MP["ModelPack<br/>OCI 模型打包 / 规范"]
-  HB["Harbor<br/>私有 OCI Registry"]
-  DF["Dragonfly<br/>P2P 分发加速"]
+    subgraph N1["Node 1"]
+      F1["本地模型缓存 / 文件"]
+      subgraph G1["GPU workers"]
+        W11["GPU 0 worker"]
+        W12["GPU 1 worker"]
+      end
+    end
 
-  CL["Inference / Kubernetes Cluster"]
-  ME["ModelExpress<br/>运行时权重传输 / 冷启动加速"]
+    subgraph N2["Node 2"]
+      F2["本地模型缓存 / 文件"]
+      subgraph G2["GPU workers"]
+        W21["GPU 0 worker"]
+        W22["GPU 1 worker"]
+      end
+    end
+  end
 
-  U -->|"HF / SDK / API"| HF
-  U -->|"SDK / API"| MS
+  DEV -->|"发布 / 同步"| HF
+  DEV -->|"发布 / 同步"| MS
+  DEV -->|"私有上传"| MX
+  DEV -->|"打包模型"| MP
 
   PHF -. "可由此实现" .-> MX
-  U -->|"HF-compatible endpoint"| MX
-  HF -->|"首次拉取 / 缓存 / 同步"| MX
-
-  HF -->|"打包为 OCI artifact"| MP
-  MS -->|"打包为 OCI artifact"| MP
   MP --> HB
-  HB --> DF
-  DF -->|"节点级 P2P 下载 / 预热"| CL
+  HF -->|"镜像 / 缓存"| MX
 
-  MX -->|"私有模型源 / 治理入口"| CL
-  CL --> ME
-  ME -->|"worker-to-worker / GPU-to-GPU"| CL
+  MX -->|"HF-compatible endpoint"| PULL
+  HF -->|"hf://"| DF
+  MS -->|"modelscope://"| DF
+  HB -->|"OCI pull"| DF
 
-  MX -. "可组合" .-> ME
-  DF -. "解决文件分发" .-> ME
+  PULL --> F1
+  PULL --> F2
+  DF --> F1
+  DF --> F2
+  F1 <-->|"node 级 P2P 文件分片"| F2
+
+  F1 --> W11
+  F1 --> W12
+  F2 --> W21
+  F2 --> W22
+
+  USER --> SVC
+  SVC --> W11
+  SVC --> W21
+
+  ME -. "权重复用" .-> W11
+  ME -. "权重复用" .-> W12
+  ME -. "权重复用" .-> W21
+  ME -. "权重复用" .-> W22
+
+  W11 <-->|"同节点 GPU / NVLink"| W12
+  W12 <-->|"跨节点 RDMA / UCX / NIXL"| W21
+  W21 <-->|"同节点 GPU / NVLink"| W22
 ```
 
-这张图的阅读方式很简单：
+这张图可以从三个视角来读：
 
-- **最左侧**是公共模型来源和开发者默认入口
-- **中间**是企业内部的私有模型入口或制品治理体系
-- **右侧**是集群内的节点分发和运行时加速
+- **模型提供方视角**：左侧是模型来源。Hugging Face 和 ModelScope 位于互联网侧，MatrixHub 和 Harbor 更适合放在企业数据中心内部。
+- **模型获取视角**：中间是下载路径。MatrixHub 更像 HF-compatible 的私有入口，Dragonfly 则是 node 级别的 P2P 文件分发层。
+- **最终使用者视角**：右侧是运行时。最终用户请求进入推理服务，模型文件先进入节点本地缓存，再由 GPU worker 消费；ModelExpress 则进一步处理 worker 之间、甚至跨 node GPU 之间的权重共享与冷启动优化。
 
 理解这一点之后，很多争论都会自然消失：这些项目大多不是彼此替代，而是站在不同层上解不同的问题。
 

--- a/docs/blog/2026-04-28/2026-04-28-understanding-model-distribution-stack_zh.md
+++ b/docs/blog/2026-04-28/2026-04-28-understanding-model-distribution-stack_zh.md
@@ -129,6 +129,8 @@ flowchart TB
   style MODEL_LANE fill:#fff1e6,stroke:#c2410c,stroke-width:2px
   style N1 fill:#f0fdf4,stroke:#16a34a,stroke-width:1px
   style N2 fill:#f0fdf4,stroke:#16a34a,stroke-width:1px
+  linkStyle 5,6,7,9,10 stroke:#c2410c,stroke-width:3px,color:#c2410c
+  linkStyle 8 stroke:#2b6cb0,stroke-width:3px,color:#2b6cb0
 ```
 
 这张图可以从三个视角来读：
@@ -137,7 +139,142 @@ flowchart TB
 - **下载获取视角**：MatrixHub 提供 HF-compatible 拉取入口；Dragonfly 负责 node 级文件分发，它既可以接 Harbor 的 OCI pull，也可以接 `hf://` 与 `modelscope://` 这类模型来源。
 - **最终使用者视角**：模型文件先进入 node 本地缓存，再进入 GPU worker；`ModelExpress` 则位于更靠后的运行时层，处理同 node 甚至跨 node GPU 之间的权重共享与冷启动优化。
 
+颜色也有含义：
+
+- **橙色线**：HF-compatible / model hub 下载路径
+- **蓝色线**：OCI pull 路径
+- **灰色 node 间线**：Dragonfly 的 node 级文件分片传播
+- **绿色 GPU 间线**：ModelExpress 关注的运行时权重共享路径
+
 理解这一点之后，很多争论都会自然消失：这些项目大多不是彼此替代，而是站在不同层上解不同的问题。
+
+## 三个单独方案图
+
+除了总图，下面三张图分别只保留各自最关键的链路。
+
+### 1. Dragonfly 方案：Harbor + 公共模型 Hub 即可
+
+```mermaid
+flowchart LR
+  classDef oci fill:#e8f3ff,stroke:#2b6cb0,color:#0f172a;
+  classDef model fill:#fff1e6,stroke:#c2410c,color:#111827;
+  classDef neutral fill:#f8fafc,stroke:#64748b,color:#111827;
+
+  HF["Hugging Face / ModelScope<br/>public model hub"]
+  HB["Harbor<br/>private OCI registry"]
+  DF["Dragonfly<br/>seed peer + scheduler + peers"]
+
+  subgraph CL["Cluster nodes"]
+    direction LR
+    N1["Node 1<br/>local file cache"]
+    N2["Node 2<br/>local file cache"]
+    N3["Node 3<br/>local file cache"]
+  end
+
+  HF -->|"hf:// / modelscope://"| DF
+  HB -->|"OCI pull"| DF
+  DF --> N1
+  DF --> N2
+  DF --> N3
+  N1 <-->|"node-level P2P file chunks"| N2
+  N2 <-->|"node-level P2P file chunks"| N3
+
+  class HB oci;
+  class HF model;
+  class DF,N1,N2,N3 neutral;
+  linkStyle 0 stroke:#c2410c,stroke-width:3px,color:#c2410c
+  linkStyle 1 stroke:#2b6cb0,stroke-width:3px,color:#2b6cb0
+```
+
+这张图强调的是：
+
+- Dragonfly 可以同时接公共模型来源和私有 OCI registry
+- 它解决的是 **node 级文件分发**
+- 它不关心 GPU 权重是否已经加载
+
+### 2. MatrixHub 方案：更像“私有 Hugging Face”
+
+```mermaid
+flowchart LR
+  classDef public fill:#fff1e6,stroke:#c2410c,color:#111827;
+  classDef private fill:#ecfdf5,stroke:#047857,color:#111827;
+  classDef client fill:#f8fafc,stroke:#64748b,color:#111827;
+
+  DEV["模型提供方 / 微调团队"]
+  HF["Hugging Face / ModelScope<br/>public model hub"]
+  MX["MatrixHub<br/>private Hugging Face<br/>HF-compatible endpoint"]
+  CLI["HF-compatible clients<br/>transformers / vLLM / SDK / CLI"]
+  N1["训练 / 评测 / 推理节点 A"]
+  N2["训练 / 评测 / 推理节点 B"]
+
+  DEV -->|"私有上传"| MX
+  HF -->|"镜像 / 缓存"| MX
+  CLI -->|"HF-compatible 拉取"| MX
+  MX --> N1
+  MX --> N2
+
+  class HF public;
+  class MX private;
+  class DEV,CLI,N1,N2 client;
+  linkStyle 1,2 stroke:#c2410c,stroke-width:3px,color:#c2410c
+```
+
+这张图强调的是：
+
+- MatrixHub 更关注 **私有模型入口与治理**
+- 它尽量保留 Hugging Face 风格的使用方式
+- 它不是专门做 GPU-to-GPU 权重搬运的组件
+
+### 3. ModelExpress 方案：只保留 HF 公共模型来源
+
+```mermaid
+flowchart LR
+  classDef public fill:#fff1e6,stroke:#c2410c,color:#111827;
+  classDef runtime fill:#ecfdf5,stroke:#047857,color:#111827;
+  classDef neutral fill:#f8fafc,stroke:#64748b,color:#111827;
+
+  HF["Hugging Face<br/>public model hub"]
+  ME["ModelExpress<br/>metadata + runtime weight P2P"]
+
+  subgraph N1["Source node"]
+    direction TB
+    F1["local model cache"]
+    W11["GPU 0 worker"]
+    W12["GPU 1 worker"]
+  end
+
+  subgraph N2["Target node"]
+    direction TB
+    F2["local model cache / fallback"]
+    W21["GPU 0 worker"]
+    W22["GPU 1 worker"]
+  end
+
+  HF -->|"first pull / seed load"| F1
+  F1 --> W11
+  F1 --> W12
+  F2 --> W21
+  F2 --> W22
+
+  ME -. "coordination" .-> W11
+  ME -. "coordination" .-> W12
+  ME -. "coordination" .-> W21
+  ME -. "coordination" .-> W22
+
+  W11 <-->|"same-node NVLink"| W12
+  W12 <-->|"cross-node RDMA / UCX / NIXL"| W21
+  W21 <-->|"same-node NVLink"| W22
+
+  class HF public;
+  class ME,W11,W12,W21,W22 runtime;
+  class F1,F2 neutral;
+```
+
+这张图强调的是：
+
+- ModelExpress 关注的是 **运行时权重共享**
+- source node 先加载模型
+- 后续 worker，尤其是跨 node 的 GPU worker，可以通过更快的路径复用权重状态
 
 ## 一、Hugging Face 与 ModelScope：它们首先是“公共模型来源”
 

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-04-15
+last_updated: 2026-04-28
 tags: blog, kubernetes, ai-infrastructure
 ---
 
@@ -11,6 +11,22 @@ Older posts have been archived to [docs/archive-blog](../archive-blog/README.md)
 
 This directory contains blog posts and articles about AI infrastructure,
 Kubernetes scheduling, and related topics.
+
+## 2026-04-28: 如何理解 Hugging Face、私有 Hugging Face、MatrixHub、Harbor + Dragonfly + ModelPack 与 ModelExpress
+
+- [如何理解 Hugging Face、私有 Hugging Face、MatrixHub、Harbor + Dragonfly + ModelPack 与 ModelExpress (Chinese)](./2026-04-28/2026-04-28-understanding-model-distribution-stack_zh.md)
+
+A Chinese architecture-oriented article that places public model hubs, private
+model hubs, OCI-first artifact stacks, node-level P2P distribution, and
+runtime weight transfer into a single model distribution view:
+
+- **Layered framing**: separates public model sources, enterprise governance,
+  node distribution, and runtime acceleration.
+- **Scenario-driven comparison**: explains when to prefer MatrixHub, when to
+  prefer Harbor + ModelPack + Dragonfly, and when ModelExpress becomes the
+  right answer.
+- **One-stack diagram**: provides a Mermaid overview covering Hugging Face,
+  ModelScope, MatrixHub, Harbor, Dragonfly, ModelPack, and ModelExpress.
 
 ## 2026-04-15: Kubernetes v1.34 PSI Metrics Beta（AI-Infra 落地）
 

--- a/docs/inference/README.md
+++ b/docs/inference/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-04-15
+last_updated: 2026-04-28
 tags: inference, llm, vllm, serving, optimization
 canonical_path: docs/inference/README.md
 ---
@@ -24,6 +24,7 @@ More details about specific platforms and techniques:
 - [Memory, Context, and Database for AI Agents](./memory-context-db.md)
 - [Large Scale Experts (MoE Models)](./large-scale-experts.md)
 - [Model Lifecycle Management (Cold-Start, Sleep Mode, Offloading)](./model-lifecycle.md)
+- [One Diagram for Model Distribution (HF, MatrixHub, Harbor, Dragonfly, ModelPack, ModelExpress)](./model-distribution-stack.md)
 - [Performance Testing & Benchmark Tools](./performance-testing.md)
 
 ## Inference Platform Landscape

--- a/docs/inference/model-distribution-stack.md
+++ b/docs/inference/model-distribution-stack.md
@@ -1,0 +1,192 @@
+---
+status: Active
+maintainer: pacoxu
+last_updated: 2026-04-28
+tags: inference, model-distribution, registry, huggingface, oci
+canonical_path: docs/inference/model-distribution-stack.md
+---
+
+# One Diagram for Model Distribution: Hugging Face, MatrixHub, Harbor, Dragonfly, ModelPack, and ModelExpress
+
+This page puts several frequently mixed-up projects on a single diagram. The
+goal is to separate the **model source**, **private registry**, **cluster
+distribution**, and **runtime acceleration** layers.
+
+## The Stack in One Diagram
+
+```mermaid
+flowchart LR
+  U["Model Consumers<br/>training / eval / vLLM / SGLang / Dynamo"]
+
+  HF["Hugging Face<br/>public model hub"]
+  PHF["Private Hugging Face<br/>(target capability)"]
+  MX["MatrixHub<br/>HF-compatible private hub"]
+
+  MP["ModelPack<br/>OCI model packaging / spec"]
+  HB["Harbor<br/>private OCI registry"]
+  DF["Dragonfly<br/>P2P distribution acceleration"]
+
+  CL["Inference / Kubernetes Cluster"]
+  ME["ModelExpress<br/>runtime weight acceleration"]
+
+  U -->|"HF Hub API"| HF
+  PHF -. "implemented by" .-> MX
+  U -->|"HF-compatible endpoint"| MX
+  HF -->|"sync / cache / first pull"| MX
+
+  HF -->|"package as OCI artifact"| MP
+  MP --> HB
+  HB --> DF
+  DF -->|"node pull / preheat / P2P"| CL
+
+  MX -->|"governed model source"| CL
+  CL --> ME
+  ME -->|"worker-to-worker / GPU-path acceleration"| CL
+  MX -. "complements" .-> ME
+```
+
+## Read the Diagram from Left to Right
+
+### 1. Hugging Face
+
+Hugging Face is the public upstream model hub. It is the default source for
+many training and inference workflows using `huggingface_hub`,
+`transformers`, `vLLM`, and similar clients.
+
+### 2. Private Hugging Face
+
+Private Hugging Face is a **target state**, not a single product. It means:
+
+- private model hosting
+- access control and governance
+- low-friction compatibility with existing HF-style workflows
+- predictable distribution inside enterprise or air-gapped environments
+
+### 3. MatrixHub
+
+MatrixHub is the most direct path to that target state in this stack. It acts
+as an **HF-compatible private hub**, so teams can keep the Hugging Face
+interaction model while moving to a governed internal endpoint.
+
+In practice, MatrixHub is the layer for:
+
+- private model registry and lifecycle governance
+- transparent HF proxy behavior
+- on-demand caching from public Hugging Face
+- multi-region or air-gapped distribution workflows
+
+### 4. ModelPack + Harbor + Dragonfly
+
+This path is different. It is **OCI-first**, not HF-first.
+
+- `ModelPack` provides a packaging/spec path for OCI-based model artifacts.
+- `Harbor` provides the private OCI registry, including enterprise governance
+  features such as RBAC, signing, replication, and retention.
+- `Dragonfly` accelerates distribution from the registry to nodes using
+  preheat and P2P transfer patterns.
+
+This stack is a strong answer to **private model artifact management**, but it
+does not by itself provide a native Hugging Face-compatible endpoint.
+
+### 5. ModelExpress
+
+ModelExpress sits later in the path. It is not the primary model hub. Its main
+job is **runtime weight movement and cold-start reduction inside the cluster**.
+
+That usually means:
+
+- coordinating cache usage in the inference cluster
+- reducing repeated model pulls and loads
+- enabling worker-to-worker transfer
+- accelerating the last mile from storage or cache toward serving workers
+
+The official documentation focuses on **in-cluster multi-node coordination**
+rather than a global multi-cluster control plane.
+
+## The Most Common Architecture Patterns
+
+### Pattern A: Public Hugging Face
+
+Use this when convenience matters more than control.
+
+`Clients -> Hugging Face`
+
+Tradeoff:
+
+- simplest workflow
+- least governance
+- repeated public downloads
+- weak fit for air-gapped or regulated environments
+
+### Pattern B: Private Hugging Face with MatrixHub
+
+Use this when existing HF workflows should remain almost unchanged.
+
+`Clients -> MatrixHub -> Hugging Face or private storage`
+
+Tradeoff:
+
+- lowest migration cost for HF-first teams
+- strong fit for internal mirroring and governance
+- less aligned with OCI-first platform standardization than Harbor
+
+### Pattern C: Private Model Registry with Harbor + ModelPack + Dragonfly
+
+Use this when the platform is already centered on OCI artifacts and Kubernetes.
+
+`Build/package -> ModelPack -> Harbor -> Dragonfly -> cluster nodes`
+
+Tradeoff:
+
+- strong standardization and enterprise controls
+- clean fit for OCI-native platform teams
+- more workflow translation if users expect native HF semantics
+
+### Pattern D: MatrixHub + ModelExpress
+
+Use this when you need both **private Hugging Face-style access** and **faster
+cluster runtime loading**.
+
+`Clients -> MatrixHub -> cluster cache/source -> ModelExpress -> workers`
+
+Division of responsibility:
+
+- `MatrixHub` is the upstream system of record and governed distribution layer.
+- `ModelExpress` is the in-cluster runtime acceleration layer.
+
+This is especially natural in multi-cluster environments where each cluster
+runs its own runtime acceleration path while a shared upstream model source
+keeps versions and access policies consistent.
+
+## Quick Positioning Table
+
+| Component | Primary layer | Best for |
+| --- | --- | --- |
+| Hugging Face | Public upstream hub | Public model discovery and default client workflows |
+| Private Hugging Face | Capability / target state | Internal HF-like experience |
+| MatrixHub | Private model hub | HF-compatible internal distribution and governance |
+| ModelPack | Packaging/spec | OCI-based model artifact definition |
+| Harbor | Private registry | OCI artifact governance and replication |
+| Dragonfly | Cluster distribution | Large-scale node-level pull acceleration |
+| ModelExpress | Runtime acceleration | In-cluster cold-start and weight transfer optimization |
+
+## Practical Rule of Thumb
+
+- If the question is **"where should models live and be governed?"**, think
+  `MatrixHub` or `Harbor`.
+- If the question is **"do we want HF-compatible developer experience or
+  OCI-first artifact workflows?"**, choose between `MatrixHub` and
+  `Harbor + ModelPack`.
+- If the question is **"how do we reduce cluster cold-start and repeated weight
+  movement?"**, think `Dragonfly` and `ModelExpress`.
+- If the question is **"how do we keep HF-like access while improving
+  last-mile runtime loading?"**, combine `MatrixHub` with `ModelExpress`.
+
+## References
+
+- [MatrixHub](https://github.com/matrixhub-ai/matrixhub)
+- [ModelExpress](https://github.com/ai-dynamo/modelexpress)
+- [Harbor](https://goharbor.io/)
+- [Dragonfly](https://d7y.io/)
+- [ModelPack](https://modelpack.org/)
+- [Hugging Face](https://huggingface.co/)

--- a/docs/inference/model-distribution-stack.md
+++ b/docs/inference/model-distribution-stack.md
@@ -112,6 +112,8 @@ flowchart TB
   style MODEL_LANE fill:#fff1e6,stroke:#c2410c,stroke-width:2px
   style N1 fill:#f0fdf4,stroke:#16a34a,stroke-width:1px
   style N2 fill:#f0fdf4,stroke:#16a34a,stroke-width:1px
+  linkStyle 5,6,7,9,10 stroke:#c2410c,stroke-width:3px,color:#c2410c
+  linkStyle 8 stroke:#2b6cb0,stroke-width:3px,color:#2b6cb0
 ```
 
 ## Read the Diagram by Role
@@ -126,6 +128,121 @@ flowchart TB
 - **End user / runtime view**: Model files first land in node-local caches,
   then feed GPU workers. ModelExpress sits later in the path and accelerates
   weight reuse between workers, including cross-node GPU transfers over RDMA.
+
+Line colors also carry meaning:
+
+- **Orange links**: HF-compatible or public model hub download paths
+- **Blue links**: OCI pull paths
+- **Grey node-to-node links**: Dragonfly node-level file chunk propagation
+- **Green GPU-to-GPU links**: runtime weight sharing paths relevant to ModelExpress
+
+## Focused Reference Diagrams
+
+### 1. Dragonfly path: Harbor plus public model hubs
+
+```mermaid
+flowchart LR
+  classDef oci fill:#e8f3ff,stroke:#2b6cb0,color:#0f172a;
+  classDef model fill:#fff1e6,stroke:#c2410c,color:#111827;
+  classDef neutral fill:#f8fafc,stroke:#64748b,color:#111827;
+
+  HF["Hugging Face / ModelScope<br/>public model hub"]
+  HB["Harbor<br/>private OCI registry"]
+  DF["Dragonfly<br/>seed peer + scheduler + peers"]
+
+  subgraph CL["Cluster nodes"]
+    direction LR
+    N1["Node 1<br/>local file cache"]
+    N2["Node 2<br/>local file cache"]
+    N3["Node 3<br/>local file cache"]
+  end
+
+  HF -->|"hf:// / modelscope://"| DF
+  HB -->|"OCI pull"| DF
+  DF --> N1
+  DF --> N2
+  DF --> N3
+  N1 <-->|"node-level P2P file chunks"| N2
+  N2 <-->|"node-level P2P file chunks"| N3
+
+  class HB oci;
+  class HF model;
+  class DF,N1,N2,N3 neutral;
+  linkStyle 0 stroke:#c2410c,stroke-width:3px,color:#c2410c
+  linkStyle 1 stroke:#2b6cb0,stroke-width:3px,color:#2b6cb0
+```
+
+### 2. MatrixHub path: private Hugging Face style access
+
+```mermaid
+flowchart LR
+  classDef public fill:#fff1e6,stroke:#c2410c,color:#111827;
+  classDef private fill:#ecfdf5,stroke:#047857,color:#111827;
+  classDef client fill:#f8fafc,stroke:#64748b,color:#111827;
+
+  DEV["Model provider / fine-tune team"]
+  HF["Hugging Face / ModelScope<br/>public model hub"]
+  MX["MatrixHub<br/>private Hugging Face<br/>HF-compatible endpoint"]
+  CLI["HF-compatible clients<br/>transformers / vLLM / SDK / CLI"]
+  N1["Training / eval / inference node A"]
+  N2["Training / eval / inference node B"]
+
+  DEV -->|"private upload"| MX
+  HF -->|"mirror / cache"| MX
+  CLI -->|"HF-compatible pull"| MX
+  MX --> N1
+  MX --> N2
+
+  class HF public;
+  class MX private;
+  class DEV,CLI,N1,N2 client;
+  linkStyle 1,2 stroke:#c2410c,stroke-width:3px,color:#c2410c
+```
+
+### 3. ModelExpress path: runtime weight sharing after initial pull
+
+```mermaid
+flowchart LR
+  classDef public fill:#fff1e6,stroke:#c2410c,color:#111827;
+  classDef runtime fill:#ecfdf5,stroke:#047857,color:#111827;
+  classDef neutral fill:#f8fafc,stroke:#64748b,color:#111827;
+
+  HF["Hugging Face<br/>public model hub"]
+  ME["ModelExpress<br/>metadata + runtime weight P2P"]
+
+  subgraph N1["Source node"]
+    direction TB
+    F1["local model cache"]
+    W11["GPU 0 worker"]
+    W12["GPU 1 worker"]
+  end
+
+  subgraph N2["Target node"]
+    direction TB
+    F2["local model cache / fallback"]
+    W21["GPU 0 worker"]
+    W22["GPU 1 worker"]
+  end
+
+  HF -->|"first pull / seed load"| F1
+  F1 --> W11
+  F1 --> W12
+  F2 --> W21
+  F2 --> W22
+
+  ME -. "coordination" .-> W11
+  ME -. "coordination" .-> W12
+  ME -. "coordination" .-> W21
+  ME -. "coordination" .-> W22
+
+  W11 <-->|"same-node NVLink"| W12
+  W12 <-->|"cross-node RDMA / UCX / NIXL"| W21
+  W21 <-->|"same-node NVLink"| W22
+
+  class HF public;
+  class ME,W11,W12,W21,W22 runtime;
+  class F1,F2 neutral;
+```
 
 ## Read the Diagram from Left to Right
 

--- a/docs/inference/model-distribution-stack.md
+++ b/docs/inference/model-distribution-stack.md
@@ -16,34 +16,97 @@ distribution**, and **runtime acceleration** layers.
 
 ```mermaid
 flowchart LR
-  U["Model Consumers<br/>training / eval / vLLM / SGLang / Dynamo"]
+  subgraph P["1. Model Providers / Repositories"]
+    DEV["Model provider / fine-tune team"]
+    subgraph NET["Internet"]
+      HF["Hugging Face<br/>public model hub"]
+      MS["ModelScope<br/>public model / dataset / API platform"]
+    end
+    subgraph IDC["Private data center"]
+      PHF["Private Hugging Face<br/>(target capability)"]
+      MX["MatrixHub<br/>HF-compatible private hub"]
+      MP["ModelPack<br/>OCI model packaging"]
+      HB["Harbor<br/>private OCI registry"]
+    end
+  end
 
-  HF["Hugging Face<br/>public model hub"]
-  PHF["Private Hugging Face<br/>(target capability)"]
-  MX["MatrixHub<br/>HF-compatible private hub"]
+  subgraph A["2. Model Acquisition / Download"]
+    PULL["HF-compatible pull<br/>SDK / CLI / API"]
+    DF["Dragonfly<br/>node-level P2P<br/>seed peer + scheduler"]
+  end
 
-  MP["ModelPack<br/>OCI model packaging / spec"]
-  HB["Harbor<br/>private OCI registry"]
-  DF["Dragonfly<br/>P2P distribution acceleration"]
+  subgraph R["3. Runtime / End Users"]
+    USER["End users / apps"]
+    SVC["Inference service<br/>vLLM / SGLang / Dynamo"]
+    ME["ModelExpress<br/>runtime weight P2P"]
 
-  CL["Inference / Kubernetes Cluster"]
-  ME["ModelExpress<br/>runtime weight acceleration"]
+    subgraph N1["Node 1"]
+      F1["Local model cache / files"]
+      subgraph G1["GPU workers"]
+        W11["GPU 0 worker"]
+        W12["GPU 1 worker"]
+      end
+    end
 
-  U -->|"HF Hub API"| HF
-  PHF -. "implemented by" .-> MX
-  U -->|"HF-compatible endpoint"| MX
-  HF -->|"sync / cache / first pull"| MX
+    subgraph N2["Node 2"]
+      F2["Local model cache / files"]
+      subgraph G2["GPU workers"]
+        W21["GPU 0 worker"]
+        W22["GPU 1 worker"]
+      end
+    end
+  end
 
-  HF -->|"package as OCI artifact"| MP
+  DEV -->|"publish / sync"| HF
+  DEV -->|"publish / sync"| MS
+  DEV -->|"private upload"| MX
+  DEV -->|"package model"| MP
+
+  PHF -. "can be implemented by" .-> MX
   MP --> HB
-  HB --> DF
-  DF -->|"node pull / preheat / P2P"| CL
+  HF -->|"mirror / cache"| MX
 
-  MX -->|"governed model source"| CL
-  CL --> ME
-  ME -->|"worker-to-worker / GPU-path acceleration"| CL
-  MX -. "complements" .-> ME
+  MX -->|"HF-compatible endpoint"| PULL
+  HF -->|"hf://"| DF
+  MS -->|"modelscope://"| DF
+  HB -->|"OCI pull"| DF
+
+  PULL --> F1
+  PULL --> F2
+  DF --> F1
+  DF --> F2
+  F1 <-->|"node-level P2P file chunks"| F2
+
+  F1 --> W11
+  F1 --> W12
+  F2 --> W21
+  F2 --> W22
+
+  USER --> SVC
+  SVC --> W11
+  SVC --> W21
+
+  ME -. "weight reuse" .-> W11
+  ME -. "weight reuse" .-> W12
+  ME -. "weight reuse" .-> W21
+  ME -. "weight reuse" .-> W22
+
+  W11 <-->|"same-node GPU / NVLink"| W12
+  W12 <-->|"cross-node RDMA / UCX / NIXL"| W21
+  W21 <-->|"same-node GPU / NVLink"| W22
 ```
+
+## Read the Diagram by Role
+
+- **Model provider view**: Public upstreams such as Hugging Face and
+  ModelScope live on the Internet side. Private upload and governance happen
+  inside the data center via MatrixHub or Harbor-based workflows.
+- **Model acquisition view**: MatrixHub serves HF-compatible pulls, while
+  Dragonfly handles node-level P2P file distribution from upstream repositories
+  or a private OCI registry.
+- **End user and runtime view**: End users reach inference services, inference
+  services schedule workers, Dragonfly gets model files onto nodes, and
+  ModelExpress accelerates weight reuse between GPU workers.
 
 ## Read the Diagram from Left to Right
 

--- a/docs/inference/model-distribution-stack.md
+++ b/docs/inference/model-distribution-stack.md
@@ -15,33 +15,49 @@ distribution**, and **runtime acceleration** layers.
 ## The Stack in One Diagram
 
 ```mermaid
-flowchart LR
-  subgraph P["1. Model Providers / Repositories"]
-    DEV["Model provider / fine-tune team"]
-    subgraph NET["Internet"]
+flowchart TB
+  classDef oci fill:#e8f3ff,stroke:#2b6cb0,color:#0f172a;
+  classDef model fill:#fff1e6,stroke:#c2410c,color:#111827;
+  classDef runtime fill:#ecfdf5,stroke:#047857,color:#111827;
+  classDef neutral fill:#f8fafc,stroke:#64748b,color:#111827;
+
+  subgraph S["1. Provider / Server View"]
+    direction LR
+
+    subgraph OCI_LANE["Docker image / OCI artifact lane"]
+      direction TB
+      DH["Docker Hub<br/>public image registry"]
+      HB["Harbor<br/>local Docker Hub / distribution<br/>private OCI registry"]
+      DH -->|"sync / replicate / private image management"| HB
+    end
+
+    subgraph MODEL_LANE["Model distribution lane"]
+      direction TB
       HF["Hugging Face<br/>public model hub"]
       MS["ModelScope<br/>public model / dataset / API platform"]
-    end
-    subgraph IDC["Private data center"]
-      PHF["Private Hugging Face<br/>(target capability)"]
-      MX["MatrixHub<br/>HF-compatible private hub"]
-      MP["ModelPack<br/>OCI model packaging"]
-      HB["Harbor<br/>private OCI registry"]
+      MX["MatrixHub<br/>private Hugging Face<br/>HF-compatible private hub"]
+      MP["ModelPack<br/>package model as OCI artifact"]
+      HF -->|"mirror / cache"| MX
+      MS -. "one public upstream" .-> MX
+      MP -->|"model enters OCI workflow"| HB
     end
   end
 
-  subgraph A["2. Model Acquisition / Download"]
-    PULL["HF-compatible pull<br/>SDK / CLI / API"]
-    DF["Dragonfly<br/>node-level P2P<br/>seed peer + scheduler"]
+  subgraph C["2. Client / Download View"]
+    direction LR
+    PULL["HF-compatible SDK / CLI / API"]
+    DF["Dragonfly<br/>node-level P2P<br/>image / artifact / model files"]
   end
 
-  subgraph R["3. Runtime / End Users"]
-    USER["End users / apps"]
+  subgraph U["3. End User / Runtime View"]
+    direction LR
+    APP["End users / apps"]
     SVC["Inference service<br/>vLLM / SGLang / Dynamo"]
-    ME["ModelExpress<br/>runtime weight P2P"]
+    ME["ModelExpress<br/>GPU worker weight P2P"]
 
     subgraph N1["Node 1"]
-      F1["Local model cache / files"]
+      direction TB
+      F1["Local image / model file cache"]
       subgraph G1["GPU workers"]
         W11["GPU 0 worker"]
         W12["GPU 1 worker"]
@@ -49,22 +65,14 @@ flowchart LR
     end
 
     subgraph N2["Node 2"]
-      F2["Local model cache / files"]
+      direction TB
+      F2["Local image / model file cache"]
       subgraph G2["GPU workers"]
         W21["GPU 0 worker"]
         W22["GPU 1 worker"]
       end
     end
   end
-
-  DEV -->|"publish / sync"| HF
-  DEV -->|"publish / sync"| MS
-  DEV -->|"private upload"| MX
-  DEV -->|"package model"| MP
-
-  PHF -. "can be implemented by" .-> MX
-  MP --> HB
-  HF -->|"mirror / cache"| MX
 
   MX -->|"HF-compatible endpoint"| PULL
   HF -->|"hf://"| DF
@@ -75,38 +83,49 @@ flowchart LR
   PULL --> F2
   DF --> F1
   DF --> F2
-  F1 <-->|"node-level P2P file chunks"| F2
+  F1 <-->|"Dragonfly: node-level P2P file chunks"| F2
 
   F1 --> W11
   F1 --> W12
   F2 --> W21
   F2 --> W22
 
-  USER --> SVC
+  APP --> SVC
   SVC --> W11
   SVC --> W21
 
-  ME -. "weight reuse" .-> W11
-  ME -. "weight reuse" .-> W12
-  ME -. "weight reuse" .-> W21
-  ME -. "weight reuse" .-> W22
+  ME -. "weight reuse / hot replica propagation" .-> W11
+  ME -. "weight reuse / hot replica propagation" .-> W12
+  ME -. "weight reuse / hot replica propagation" .-> W21
+  ME -. "weight reuse / hot replica propagation" .-> W22
 
   W11 <-->|"same-node GPU / NVLink"| W12
   W12 <-->|"cross-node RDMA / UCX / NIXL"| W21
   W21 <-->|"same-node GPU / NVLink"| W22
+
+  class DH,HB oci;
+  class HF,MS,MX,MP,PULL model;
+  class DF,F1,F2 neutral;
+  class APP,SVC,ME,W11,W12,W21,W22 runtime;
+
+  style OCI_LANE fill:#e8f3ff,stroke:#2b6cb0,stroke-width:2px
+  style MODEL_LANE fill:#fff1e6,stroke:#c2410c,stroke-width:2px
+  style N1 fill:#f0fdf4,stroke:#16a34a,stroke-width:1px
+  style N2 fill:#f0fdf4,stroke:#16a34a,stroke-width:1px
 ```
 
 ## Read the Diagram by Role
 
-- **Model provider view**: Public upstreams such as Hugging Face and
-  ModelScope live on the Internet side. Private upload and governance happen
-  inside the data center via MatrixHub or Harbor-based workflows.
-- **Model acquisition view**: MatrixHub serves HF-compatible pulls, while
-  Dragonfly handles node-level P2P file distribution from upstream repositories
-  or a private OCI registry.
-- **End user and runtime view**: End users reach inference services, inference
-  services schedule workers, Dragonfly gets model files onto nodes, and
-  ModelExpress accelerates weight reuse between GPU workers.
+- **Provider / server view**: The blue lane is the Docker image / OCI artifact
+  path. Harbor is easiest to read here as a local Docker Hub / Distribution
+  style private registry. The orange lane is the model distribution path, with
+  Hugging Face, ModelScope, and MatrixHub on that side.
+- **Download view**: MatrixHub exposes an HF-compatible pull path. Dragonfly
+  handles node-level file distribution and can serve OCI pulls from Harbor as
+  well as `hf://` and `modelscope://` downloads.
+- **End user / runtime view**: Model files first land in node-local caches,
+  then feed GPU workers. ModelExpress sits later in the path and accelerates
+  weight reuse between workers, including cross-node GPU transfers over RDMA.
 
 ## Read the Diagram from Left to Right
 
@@ -144,7 +163,9 @@ This path is different. It is **OCI-first**, not HF-first.
 
 - `ModelPack` provides a packaging/spec path for OCI-based model artifacts.
 - `Harbor` provides the private OCI registry, including enterprise governance
-  features such as RBAC, signing, replication, and retention.
+  features such as RBAC, signing, replication, and retention. A useful mental
+  model is to treat it as an enterprise-local Docker Hub / Distribution style
+  system with stronger management features.
 - `Dragonfly` accelerates distribution from the registry to nodes using
   preheat and P2P transfer patterns.
 


### PR DESCRIPTION
## What changed

This PR now contains two related docs:

1. `docs/inference/model-distribution-stack.md`
   - adds a Mermaid diagram that places Hugging Face, private Hugging Face, MatrixHub, Harbor + ModelPack + Dragonfly, and ModelExpress into one stack
2. `docs/blog/2026-04-28/2026-04-28-understanding-model-distribution-stack_zh.md`
   - adds a Chinese long-form article that explains the different problem layers, scenarios, and tradeoffs behind those projects

It also updates the corresponding index pages:

- `docs/inference/README.md`
- `docs/blog/README.md`

## Why

These projects are often discussed as if they were direct substitutes, but they usually sit at different layers:

- public model source
- private model hub or artifact governance
- node-level distribution
- in-cluster runtime acceleration

The goal of this PR is to make that separation visible in both a quick diagram and a longer scenario-driven article.

## Impact

- adds a GitHub-rendered Mermaid overview diagram
- adds a Chinese article that is easier to share as a standalone explanation
- clarifies when MatrixHub, Harbor + ModelPack + Dragonfly, and ModelExpress complement each other instead of competing
- keeps the scope doc-only

## Validation

- `git diff --check`
- manual review of Markdown structure and Mermaid blocks
