### PR TITLE
[codex] add bilingual inference orchestration stack guide

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -1,0 +1,20 @@
+---
+status: Active
+maintainer: pacoxu
+last_updated: 2026-05-14
+tags: blog, ai-infrastructure
+---
+
+# Blog
+
+This page is the public entry point for blog posts in `AI-Infra`.
+
+## Blog Index
+
+- [Full Blog List](./docs/blog/README.md)
+- [Archived Blog Posts](./docs/archive-blog/README.md)
+
+## Recent Posts
+
+- [How to choose an inference orchestration stack: AIBrix, Kthena, Dynamo, llm-d, KServe, vLLM Production Stack, and SGLang/RBG](./docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks.md)
+- [推理编排方案如何选择？AIBrix、Kthena、Dynamo、llm-d、KServe、vLLM Production Stack 与 SGLang/RBG](./docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks_zh.md)

--- a/README.md
+++ b/README.md
@@ -105,10 +105,7 @@ where to focus their learning.
 
 #### Blog
 
-- [Blog Overview](./docs/blog/README.md)
-- [Latest: vLLM v0.18.0 Release (Chinese)](./docs/blog/2026-03-24/2026-03-24-vllm-v0.18.0-ai-infra-highlights_zh.md)
-- [Latest: NVIDIA AICR Intro (Chinese)](./docs/blog/2026-03-13/2026-03-13-nvidia-aicr-introduction_zh.md)
-- [Latest: Bayer 15K-Node GKE Retrospective (Chinese)](./docs/blog/2026-03-13/2026-03-13-bayer-gke-15000-nodes_zh.md)
+- [Blog List](./BLOG.md)
 
 ## 📊 AI-Infra Landscape (2026 March)
 

--- a/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks.md
+++ b/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks.md
@@ -1,0 +1,442 @@
+---
+status: Active
+maintainer: pacoxu
+date: 2026-05-13
+tags: inference, orchestration, kubernetes, llm, pd-disaggregation, llm-d, kserve, dynamo, aibrix, kthena, sglang, rbg, vllm
+canonical_path: docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks.md
+source_urls:
+  - https://kserve.github.io/website/
+  - https://kserve.github.io/website/docs/model-serving/generative-inference/llmisvc/llmisvc-overview
+  - https://kserve.github.io/website/docs/model-serving/generative-inference/llmisvc/llmisvc-envoy-ai-gateway
+  - https://kserve.github.io/website/blog/cloud-native-ai-inference-kserve-llm-d
+  - https://github.com/llm-d/llm-d
+  - https://github.com/llm-d/llm-d/releases
+  - https://llm-d.ai/docs/architecture/architecture
+  - https://github.com/vllm-project/production-stack
+  - https://github.com/vllm-project/production-stack/releases
+  - https://docs.vllm.ai/en/latest/deployment/integrations/production-stack.html
+  - https://github.com/vllm-project/aibrix
+  - https://github.com/vllm-project/aibrix/releases
+  - https://aibrix.readthedocs.io/latest/getting_started/installation/installation.html
+  - https://aibrix.readthedocs.io/latest/designs/aibrix-stormservice.html
+  - https://aibrix.readthedocs.io/latest/designs/aibrix-router.html
+  - https://aibrix.readthedocs.io/latest/features/autoscaling/metric-based-autoscaling.html
+  - https://kthena.volcano.sh/docs/intro
+  - https://kthena.volcano.sh/docs/v0.2.0/architecture
+  - https://github.com/volcano-sh/kthena/blob/main/docs/proposal/modelserving-role-support-leaderworkerset.md
+  - https://github.com/volcano-sh/kthena/pull/767
+  - https://volcano.sh/en/blog/introducing-kthena-redefining-llm-inference-for-the-cloud-native-era/
+  - https://docs.nvidia.com/dynamo/latest/kubernetes-deployment/deployment-guide
+  - https://docs.nvidia.com/dynamo/latest/kubernetes-deployment/multinode/grove
+  - https://docs.nvidia.com/dynamo/components/planner/planner-guide
+  - https://github.com/ai-dynamo/dynamo
+  - https://docs.sglang.io/
+  - https://docs.sglang.io/advanced_features/router.html
+  - https://github.com/sgl-project/sglang/releases
+  - https://github.com/sgl-project/rbg
+  - https://github.com/kubernetes-sigs/lws/blob/main/keps/766-DisaggregatedSet/README.md
+---
+
+# How to choose an inference orchestration stack: AIBrix, Kthena, Dynamo, llm-d, KServe, vLLM Production Stack, and SGLang/RBG
+
+This post is based on public information checked as of **2026-05-13**. It is intended for technical reference only. Real-world outcomes depend heavily on workload shape, GPU and network topology, existing control planes, operational maturity, and ecosystem fit. A project's current design should not be treated as its final direction. Community openness, activity, and long-term convergence matter at least as much as any single release.
+
+## TL;DR
+
+The most common mistake in this space is not choosing the wrong project. It is comparing **different layers** as if they were interchangeable:
+
+- `vLLM` and `SGLang` are primarily **runtimes / inference engines**
+- `vLLM Production Stack` and `llm-d` are primarily **serving stacks**
+- `KServe`, `AIBrix`, `Kthena`, and `Dynamo` are primarily **platforms / control planes**
+- `RBG` and `LWS/DisaggregatedSet` are primarily **workload primitives / orchestration APIs**
+
+If you only keep one short decision guide:
+
+- Already deep in `Volcano`: start with `Kthena`
+- Already standardized on `KServe`: think `KServe + llm-d`
+- Pure `vLLM` team and want the lightest path first: start with `vLLM Production Stack`
+- `NVIDIA` cluster and performance system capability is the top priority: start with `Dynamo`
+- Want a modular platform on vanilla Kubernetes: start with `AIBrix`
+- Already committed to `SGLang`: start with `SGLang Model Gateway`; add `RBG` only if you also need a first-class multi-role Kubernetes workload API
+
+## 1. What changed over the last year
+
+In 2025, this topic was often framed as “everyone is doing PD disaggregation.” In 2026, that framing is no longer enough.
+
+The real convergence is broader:
+
+- the problem is no longer just “how to launch pods”
+- `prefill/decode` is no longer just an optimization trick
+- the control plane now needs to reason about **roles, routing, KV locality, autoscaling, topology, and failure handling**
+
+Several old assumptions need updating:
+
+- `AIBrix` is no longer just “the KubeRay option.” Its installation guide now explicitly states that `KubeRay` is optional, and `StormService` can run both single-node and multi-node inference without it.
+- `Dynamo` should no longer be summarized as “Grove mode vs LWS mode.” Its Kubernetes story is now clearly structured around `DGDR/DGD + Operator + Planner + Grove`.
+- `KServe` and `llm-d` should not be treated as mutually exclusive. KServe `0.17` documentation explicitly says `LLMInferenceService` is built on `llm-d`.
+- `SGLang` is no longer only a runtime. Its `Model Gateway` now covers routing, Kubernetes service discovery, PD topologies, reliability controls, and Inference Gateway Mode.
+
+## 2. Compare by layer, not by brand name
+
+| Layer | Representative projects | What they are really solving |
+| --- | --- | --- |
+| Runtime / Engine | `vLLM`, `SGLang` | Efficient execution inside one pod or a tightly scoped serving backend |
+| Serving Stack | `vLLM Production Stack`, `llm-d` | Turning runtimes into routable, observable, scalable cluster services |
+| Platform / Control Plane | `KServe`, `AIBrix`, `Kthena`, `Dynamo` | Unifying lifecycle, routing, policy, scaling, and operational control |
+| Workload Primitive | `RBG`, `LWS/DisaggregatedSet` | Giving Kubernetes a better API for tightly coupled multi-role AI workloads |
+
+This perspective changes the decision entirely:
+
+- if you need a unified entry point and governance model, compare `KServe / AIBrix / Kthena / Dynamo`
+- if you need a high-performance distributed serving path, compare `llm-d / vLLM Production Stack / SGLang Gateway`
+- if you need a multi-role workload API, compare `RBG / LWS / DisaggregatedSet`
+
+## 3. KServe: a unified AI inference platform, not just a runtime wrapper
+
+As of `2026-05-13`, KServe positions itself as a **Standardized Distributed Generative and Predictive AI Inference Platform**. The most important recent shift is not merely “KServe supports LLMs.” It is that KServe now has a dedicated GenAI path through `LLMInferenceService`.
+
+The `0.17` documentation is explicit:
+
+- `LLMInferenceService` is a dedicated CRD for Generative AI workloads
+- it is built on top of `llm-d`
+- it exposes multi-node inference, PD separation, advanced routing, and DP+EP patterns at the platform API layer
+- it keeps KServe's traditional strengths around lifecycle, unified API, Gateway API integration, and governance
+
+That means many teams should stop asking “KServe or llm-d?” and instead ask:
+
+Should `KServe` be my control plane, and is `llm-d` the distributed serving layer I want under it?
+
+If you already have:
+
+- `Knative` or `KServe` operational experience
+- standard Kubernetes API driven model delivery
+- a need for shared gateways, quotas, and platform governance
+
+then `KServe + llm-d` is often the most natural path.
+
+## 4. llm-d: a high-performance distributed serving stack
+
+`llm-d` is now much easier to position. It is not a general platform and not just a deployment template for `vLLM`. It is a **Kubernetes-native distributed inference serving stack**.
+
+As of `v0.7.0` on **2026-05-12**, the official release and architecture materials show a fairly complete stack:
+
+- Router and Scheduler as first-class components
+- KV cache aware routing
+- Prefill/Decode disaggregation
+- `LeaderWorkerSet` as a multi-node orchestration path
+- variant autoscaling
+- integration with the Gateway API inference extension
+- a more explicit `SGLang` path in the official guides
+
+Its value is fundamentally about **cluster-wide intelligence**, not just making one runtime pod faster:
+
+- whether requests preserve prefix-cache locality
+- whether prefill and decode land in the right resource pools
+- whether the router can make better endpoint choices than generic load balancing
+- whether tail latency and GPU utilization remain sane under large-model and multi-tenant pressure
+
+If you already know you need:
+
+- cluster-wide cache-aware routing
+- role-aware or PD-aware serving
+- stronger serving intelligence than `vLLM + Service`
+
+then `llm-d` is one of the clearest options available today.
+
+## 5. vLLM Production Stack: a lighter upstream reference stack
+
+`vLLM Production Stack` should not be understood on the same layer as `llm-d`, `KServe`, or `Dynamo`. Its official README is more modest and more honest: it is **vLLM’s reference system for K8S-native cluster-wide deployment**.
+
+As of `2026-05-07`, the latest release is `vllm-stack-0.1.11`. The current public shape is centered around:
+
+- Helm-based deployment
+- a request router
+- Prometheus + Grafana observability
+- LMCache / KV cache offloading
+- scaling from a single vLLM instance to distributed vLLM without changing application code
+
+That makes it attractive in a specific way:
+
+- it is the most natural option for teams already standardized on `vLLM`
+- it is thinner and closer to an upstream reference deployment than to a full platform
+- it gives you routing, observability, and cache offloading without forcing a larger control-plane adoption up front
+
+Its boundary is equally clear:
+
+- it is not a unified control plane
+- it does not aim to provide the governance surface of `KServe / AIBrix / Kthena / Dynamo`
+- it is better viewed as a practical starting point than as the final answer to every multi-role orchestration problem
+
+If your question is simply “how do I run an upstream-style vLLM cluster on Kubernetes cleanly?”, this is a very reasonable first stop.
+
+## 6. SGLang and RBG: keep runtime/gateway and workload API separate
+
+These two are often mentioned together, but they solve different layers.
+
+### 6.1 SGLang: a high-performance runtime with an increasingly capable Model Gateway
+
+The current SGLang documentation emphasizes two things at once:
+
+- SGLang is a high-performance serving framework with PD disaggregation, HiCache, multiple parallelism modes, and broad hardware coverage
+- SGLang now also has a `Model Gateway` that handles HTTP/gRPC/OpenAI-compatible routing, Kubernetes service discovery, PD topologies, observability, and reliability controls
+
+As of `v0.5.11` on **2026-05-05**, one especially important signal is the continued push toward **Unified Inference Gateway Mode**. That means SGLang is no longer only a runtime. It is also becoming a more complete serving entry point.
+
+If your team is already committed to SGLang, the first decision is often not “which platform should replace it?” but rather:
+
+- use `SGLang` as the runtime
+- use `SGLang Model Gateway` to extend it into a manageable fleet entry point
+
+### 6.2 RBG: a multi-role workload primitive
+
+`RBG` does not compete with a gateway. Its value is in `RoleBasedGroup` as a Kubernetes workload API for tightly coordinated distributed inference services.
+
+Its README explicitly highlights:
+
+- role startup-order dependencies
+- automated service discovery
+- group-level and role-level elastic scaling
+- atomic rollout
+- topology-aware placement
+- atomic failure recovery
+- support for multiple role backends, including `StatefulSet`, `Deployment`, and `LeaderWorkerSet`
+
+So the cleaner mental model is:
+
+- `SGLang` solves runtime and gateway
+- `RBG` solves how a multi-role inference service is expressed and orchestrated on Kubernetes
+
+If you are already on `SGLang` and feel that plain `Deployment` or `StatefulSet` is too weak for multi-role serving, `RBG` becomes relevant very quickly.
+
+## 7. AIBrix: a modular GenAI infrastructure platform
+
+`AIBrix` is increasingly best understood as a **modular platform**, not a single CRD.
+
+As of `v0.6.0` on **2026-03-03** and the latest official documentation, several signals are clear:
+
+- vanilla Kubernetes is a first-class deployment path
+- `Envoy Gateway` is a required entry layer
+- `KubeRay` is optional
+- `StormService` is a main orchestration path for multi-node inference
+- router, KV cache, pod autoscaler, and LoRA-related components all evolve as distinct platform modules
+
+`StormService` itself matters because it is not just a prefill/decode template. It is designed as a three-layer architecture:
+
+- `StormService`
+- `RoleSet`
+- `Pods`
+
+and it already supports:
+
+- replica mode
+- pooled mode
+- top-level rolling and inplace update
+- RoleSet-level parallel, sequential, and interleaved update strategies
+
+More importantly, the current autoscaling docs explicitly describe **role-level autoscaling in pooled mode**. That is a stronger signal than simply saying “supports PD,” because it reaches the real systems problem: different roles have different load signatures and should not always scale as a single unit.
+
+If your preference is:
+
+- vanilla Kubernetes
+- a composable platform
+- router, autoscaler, KV, and LoRA management as platform capabilities
+- avoiding deep dependence on either `Volcano` or NVIDIA’s full stack
+
+then `AIBrix` is a strong candidate.
+
+## 8. Kthena: a Volcano-native inference control plane
+
+Kthena is no longer a small side effort near Volcano. The `v0.4.0` documentation defines it directly as a **Kubernetes-native AI serving platform**.
+
+Its current value is not just “it also supports PD.” It is that it organizes the following into a coherent service-oriented platform model:
+
+- `ModelBooster`
+- `ModelRoute`
+- `ModelServer`
+- `ModelServing`
+- `AutoScalingPolicy`
+- `AutoScalingPolicyBinding`
+
+From the current docs and official launch blog, its strengths are clear:
+
+- native affinity with the `Volcano` scheduling ecosystem
+- multi-backend support across `vLLM`, `SGLang`, `Triton`, and `TorchServe`
+- request-level intelligent routing
+- token-based rate limiting, canaries, and failover
+- role-aware PD routing
+- multi-metric, cost-driven autoscaling
+
+Another important evolution is Kthena’s posture toward LWS. Its public proposal and follow-up PRs show that it is not rejecting `LeaderWorkerSet`. Instead, it is exploring **LWS API compatibility**, treating LWS as one possible northbound interface rather than as the only internal primitive.
+
+If you already stand on:
+
+- `Volcano`
+- gang scheduling
+- topology-aware placement
+- heterogeneous accelerator orchestration
+
+then Kthena is often the most native-feeling answer.
+
+## 9. Dynamo: a performance-system-first inference platform
+
+Dynamo should not be reduced to “an orchestrator.” Its official docs clearly show a broader stack:
+
+- `DynamoGraphDeploymentRequest (DGDR)`: the recommended simplified, SLA-driven entry point
+- `DynamoGraphDeployment (DGD)`: a more direct low-level deployment path
+- `Planner`
+- `Profiler`
+- `Router`
+- `KVBM`
+- multi-node orchestration through `Grove`
+
+The Kubernetes deployment guide and Grove documentation make the current direction explicit:
+
+- the platform layer is centered on `DGDR/DGD + Operator`
+- multi-node, multi-role orchestration is primarily handled through `Grove`
+- `Planner` helps turn SLA intent into deployment shape and scaling decisions
+
+`Grove` is especially important because it publicly frames itself as:
+
+- a Kubernetes API designed for modern AI workloads, especially disaggregated inference
+- a unified way to express prefill, decode, routing, and other components inside one resource
+- a path for multi-level horizontal autoscaling, startup dependencies, and topology-aware scheduling
+
+So the more accurate statement today is not “Dynamo has a Grove mode and an LWS mode.” It is:
+
+Dynamo has assembled a broader performance-oriented platform, and `Grove` is the key Kubernetes orchestration path for its multi-role, multi-node serving story.
+
+If your environment is primarily:
+
+- `NVIDIA`
+- large-model and multi-node
+- strongly SLA-driven
+- interested in profiler/planner/backend/KV-path optimization as one system
+
+then `Dynamo` remains especially compelling.
+
+## 10. A more useful comparison table
+
+| Option | Real role | `role / PD` support | Routing / gateway | Scaling | Ecosystem center of gravity |
+| --- | --- | --- | --- | --- | --- |
+| `KServe` | Unified AI inference platform | Strong, exposed through `LLMInferenceService` | Strong | Strong | Standard Kubernetes platform teams |
+| `llm-d` | Distributed serving stack | Very strong | Very strong | Strong | High-performance distributed LLM serving |
+| `vLLM Production Stack` | Upstream reference stack | Present but not its most distinctive selling point | Medium to strong | Medium | Pure `vLLM` users |
+| `SGLang` | Runtime + gateway | Very strong | Very strong | Medium to strong | `SGLang` runtime users |
+| `RBG` | Multi-role workload API | Core capability | Primarily service discovery | Strong | Teams needing a generic multi-role primitive |
+| `AIBrix` | Modular GenAI infrastructure platform | Very strong, especially via `StormService / RoleSet` | Strong | Strong, including role-level autoscaling | Vanilla Kubernetes + platform composition |
+| `Kthena` | Volcano-native AI serving platform | Very strong, especially via `ModelServing / ServingGroup / Role` | Very strong | Very strong | Volcano / scheduling and topology first |
+| `Dynamo` | Performance-first AI infrastructure platform | Very strong, especially via `DGDR/DGD + Grove` | Very strong | Very strong, with planner emphasis | NVIDIA / multi-node / SLA-driven teams |
+
+## 11. How to choose based on your existing infrastructure
+
+The matrix below is intentionally simplified. In real deployments you still need to account for model size, GPU generation, network topology, cost model, platform-team maturity, and multi-tenant boundaries.
+
+### If you are already a Volcano user
+
+Start with `Kthena`.
+
+The point is not just that it supports inference. The point is that it keeps:
+
+- gang scheduling
+- topology-aware scheduling
+- role-aware inference orchestration
+- route/scale/policy control
+
+inside one ecosystem.
+
+### If you are already a KServe user
+
+Start with `KServe + llm-d`, not “KServe or llm-d.”
+
+`KServe` is the control plane. `llm-d` is the distributed serving intelligence. For teams already built around `InferenceService`, Gateway API, and platform governance, this is usually the cleanest next step.
+
+### If you are primarily a vLLM shop
+
+Decide whether you want the lightest path or the most capable serving stack:
+
+- if you want an upstream-style reference deployment first, choose `vLLM Production Stack`
+- if you already know you need cache-aware routing, PD, and cluster-level serving intelligence, choose `llm-d`
+
+### If you are primarily an NVIDIA shop
+
+Start with `Dynamo`, especially if you care about:
+
+- multi-node large-model serving
+- strong SLA-driven deployment behavior
+- using profiler and planner to guide deployment shape
+- joint optimization across backend, KV, routing, and orchestration layers
+
+### If you are a vanilla Kubernetes platform team
+
+Start with `AIBrix`.
+
+Its current balance between platform modularity and limited scheduler lock-in is clear. It gives you a natural way to compose:
+
+- `Envoy Gateway`
+- `StormService`
+- `Router`
+- `PodAutoscaler`
+- `KV Cache`
+
+without requiring a full shift into either `Volcano` or NVIDIA’s broader stack.
+
+### If you are an SGLang team
+
+The usual progression is:
+
+1. `SGLang runtime`
+2. `SGLang Model Gateway`
+3. add `RBG` only if you also need a stronger Kubernetes multi-role workload API
+
+In other words, `SGLang` and `RBG` are often complementary rather than substitutes.
+
+### If you want the most upstream-style primitive path
+
+Pay closer attention to:
+
+- `RBG`
+- `LWS + DisaggregatedSet`
+
+These matter more as workload APIs than as full inference platforms.
+
+## 12. PD disaggregation is still not the default answer
+
+This point remains true.
+
+Even though nearly every major direction now strengthens `prefill/decode` separation, supporting PD does not mean PD is automatically worth the operational and systems complexity.
+
+PD tends to make the most sense when:
+
+- prompts are long and outputs are relatively short
+- concurrency is high and request shapes vary widely
+- prefill and decode prefer different hardware or different resource pools
+- you truly need to optimize `TTFT` and `TPOT` separately
+
+You should be more cautious when:
+
+- contexts are short or models are small to medium
+- concurrency is low
+- hardware is homogeneous
+- KV transfer and cross-role coordination may erase the gains
+- your team does not yet have the observability and operational maturity to support the added moving parts
+
+The real progress today is that platforms are turning PD from a lab technique into an operable system capability. It is still not a free win.
+
+## Conclusion
+
+As of `2026-05-13`, the main story is no longer “who supports PD.” It is “who can turn role-aware orchestration, routing, autoscaling, topology, and failure handling into a system that teams can actually run.”
+
+So the real decision is not only “AIBrix or Kthena or Dynamo.” It is:
+
+- are you choosing a **runtime**, a **serving stack**, a **platform**, or a **workload API**
+- do you care more about **ecosystem compatibility** or **performance-system capability**
+- do you want to stay close to **upstream generic abstractions** or accept deeper alignment with a stronger ecosystem-specific stack
+
+If you only keep one line:
+
+- want a modular platform: `AIBrix`
+- want a Volcano-native inference control plane: `Kthena`
+- want a performance-system-first path, especially for NVIDIA: `Dynamo`
+- want high-performance distributed serving on Kubernetes: `llm-d`
+- want the lightest upstream-style vLLM deployment path first: `vLLM Production Stack`
+- already live in the SGLang world: `SGLang Gateway + RBG`

--- a/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks.md
+++ b/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks.md
@@ -39,159 +39,142 @@ source_urls:
 
 # How to choose an inference orchestration stack: AIBrix, Kthena, Dynamo, llm-d, KServe, vLLM Production Stack, and SGLang/RBG
 
-This post is based on public information checked as of **2026-05-13**. It is intended for technical reference only. Real-world outcomes depend heavily on workload shape, GPU and network topology, existing control planes, operational maturity, and ecosystem fit. A project's current design should not be treated as its final direction. Community openness, activity, and long-term convergence matter at least as much as any single release.
+This post is based on public information checked as of **2026-05-13**. It is intended for technical reference only. Real-world outcomes depend heavily on workload shape, GPU and network topology, existing control planes, operating model, and ecosystem fit. A project's current design should not be treated as its final direction. Community openness, activity, and long-term convergence matter at least as much as any single release.
 
-## TL;DR
+## Summary
 
-The most common mistake in this space is not choosing the wrong project. It is comparing **different layers** as if they were interchangeable:
+A layer-based view helps organize the comparison:
 
 - `vLLM` and `SGLang` are primarily **runtimes / inference engines**
 - `vLLM Production Stack` and `llm-d` are primarily **serving stacks**
 - `KServe`, `AIBrix`, `Kthena`, and `Dynamo` are primarily **platforms / control planes**
 - `RBG` and `LWS/DisaggregatedSet` are primarily **workload primitives / orchestration APIs**
 
-If you only keep one short decision guide:
+From the current public materials:
 
-- Already deep in `Volcano`: start with `Kthena`
-- Already standardized on `KServe`: think `KServe + llm-d`
-- Pure `vLLM` team and want the lightest path first: start with `vLLM Production Stack`
-- `NVIDIA` cluster and performance system capability is the top priority: start with `Dynamo`
-- Want a modular platform on vanilla Kubernetes: start with `AIBrix`
-- Already committed to `SGLang`: start with `SGLang Model Gateway`; add `RBG` only if you also need a first-class multi-role Kubernetes workload API
+- `KServe` has a distinct Generative AI path through `LLMInferenceService`, explicitly built on top of `llm-d`
+- `llm-d` is converging toward a fuller distributed serving stack with routing, KV locality, PD, and cluster-level scheduling intelligence
+- `vLLM Production Stack` remains closer to an upstream deployment stack than to a unified control plane
+- `SGLang` now spans both runtime and gateway concerns; `RBG` covers the multi-role workload API side
+- `LWS/DisaggregatedSet` is beginning to turn coordinated multi-LWS updates and revision-aware service orchestration into an upstream primitive
+- `AIBrix`, `Kthena`, and `Dynamo` all expose broader platform surfaces, each tied to a different ecosystem and optimization path
 
-## 1. What changed over the last year
+## 1. Current landscape
 
-In 2025, this topic was often framed as “everyone is doing PD disaggregation.” In 2026, that framing is no longer enough.
+The current generation of inference orchestration stacks is addressing the same broader set of systems problems:
 
-The real convergence is broader:
+- **role orchestration**: how prefill, decode, router, gateway, and related roles are expressed and coordinated
+- **traffic entry**: how routing reacts to topology, cache locality, revision state, and load
+- **KV and state locality**: how data locality is maintained across replicas, roles, and nodes
+- **scaling**: whether scaling happens per role, per workload, per SLA, or under platform policy
+- **rollout and recovery**: how multi-role services coordinate upgrade, rollback, and failure recovery
 
-- the problem is no longer just “how to launch pods”
-- `prefill/decode` is no longer just an optimization trick
-- the control plane now needs to reason about **roles, routing, KV locality, autoscaling, topology, and failure handling**
+From the current public materials:
 
-Several old assumptions need updating:
+- `KServe` is acting as a unified platform entry point
+- `llm-d` is one of the clearest distributed serving paths
+- `vLLM Production Stack` is a lighter upstream deployment stack
+- `SGLang` now spans runtime and gateway
+- `RBG` and `DisaggregatedSet` are closer to upstream workload APIs
+- `AIBrix`, `Kthena`, and `Dynamo` are all forming more explicit platform stories
 
-- `AIBrix` is no longer just “the KubeRay option.” Its installation guide now explicitly states that `KubeRay` is optional, and `StormService` can run both single-node and multi-node inference without it.
-- `Dynamo` should no longer be summarized as “Grove mode vs LWS mode.” Its Kubernetes story is now clearly structured around `DGDR/DGD + Operator + Planner + Grove`.
-- `KServe` and `llm-d` should not be treated as mutually exclusive. KServe `0.17` documentation explicitly says `LLMInferenceService` is built on `llm-d`.
-- `SGLang` is no longer only a runtime. Its `Model Gateway` now covers routing, Kubernetes service discovery, PD topologies, reliability controls, and Inference Gateway Mode.
+## 2. Layered view
 
-## 2. Compare by layer, not by brand name
-
-| Layer | Representative projects | What they are really solving |
+| Layer | Representative projects | Main responsibility |
 | --- | --- | --- |
-| Runtime / Engine | `vLLM`, `SGLang` | Efficient execution inside one pod or a tightly scoped serving backend |
-| Serving Stack | `vLLM Production Stack`, `llm-d` | Turning runtimes into routable, observable, scalable cluster services |
-| Platform / Control Plane | `KServe`, `AIBrix`, `Kthena`, `Dynamo` | Unifying lifecycle, routing, policy, scaling, and operational control |
-| Workload Primitive | `RBG`, `LWS/DisaggregatedSet` | Giving Kubernetes a better API for tightly coupled multi-role AI workloads |
+| Runtime / Engine | `vLLM`, `SGLang` | Execute inference inside one pod or a tightly coupled serving backend |
+| Serving Stack | `vLLM Production Stack`, `llm-d` | Turn runtimes into routable, observable, scalable cluster services |
+| Platform / Control Plane | `KServe`, `AIBrix`, `Kthena`, `Dynamo` | Use CRDs, routers, autoscalers, and policy to manage the inference lifecycle |
+| Workload Primitive | `RBG`, `LWS/DisaggregatedSet` | Provide a better Kubernetes API for tightly coordinated multi-role AI workloads |
 
-This perspective changes the decision entirely:
+This separation matters for comparison:
 
-- if you need a unified entry point and governance model, compare `KServe / AIBrix / Kthena / Dynamo`
-- if you need a high-performance distributed serving path, compare `llm-d / vLLM Production Stack / SGLang Gateway`
-- if you need a multi-role workload API, compare `RBG / LWS / DisaggregatedSet`
+- `KServe / AIBrix / Kthena / Dynamo` are most naturally compared at the platform layer
+- `llm-d / vLLM Production Stack / SGLang Gateway` are most naturally compared at the serving-stack layer
+- `RBG / LWS / DisaggregatedSet` are most naturally compared at the workload-primitive layer
 
-## 3. KServe: a unified AI inference platform, not just a runtime wrapper
+## 3. KServe
 
-As of `2026-05-13`, KServe positions itself as a **Standardized Distributed Generative and Predictive AI Inference Platform**. The most important recent shift is not merely “KServe supports LLMs.” It is that KServe now has a dedicated GenAI path through `LLMInferenceService`.
+As of `2026-05-13`, KServe positions itself as a **Standardized Distributed Generative and Predictive AI Inference Platform**. Its Generative AI path is expressed through a dedicated `LLMInferenceService`.
 
-The `0.17` documentation is explicit:
+The public `0.17` documentation is explicit:
 
 - `LLMInferenceService` is a dedicated CRD for Generative AI workloads
 - it is built on top of `llm-d`
 - it exposes multi-node inference, PD separation, advanced routing, and DP+EP patterns at the platform API layer
-- it keeps KServe's traditional strengths around lifecycle, unified API, Gateway API integration, and governance
+- it retains KServe’s traditional strengths around unified APIs, lifecycle management, Gateway API integration, and governance
 
-That means many teams should stop asking “KServe or llm-d?” and instead ask:
+In practice, the relationship is:
 
-Should `KServe` be my control plane, and is `llm-d` the distributed serving layer I want under it?
+- `KServe` as the platform entry point and governance layer
+- `llm-d` as the distributed serving layer underneath
 
-If you already have:
+This combination aligns with environments already centered on standard Kubernetes APIs, unified model delivery, and shared gateway policies.
 
-- `Knative` or `KServe` operational experience
-- standard Kubernetes API driven model delivery
-- a need for shared gateways, quotas, and platform governance
+## 4. llm-d
 
-then `KServe + llm-d` is often the most natural path.
+`llm-d` is currently best understood as a **Kubernetes-native distributed inference serving stack**, not as a general platform and not merely as a `vLLM` deployment template.
 
-## 4. llm-d: a high-performance distributed serving stack
-
-`llm-d` is now much easier to position. It is not a general platform and not just a deployment template for `vLLM`. It is a **Kubernetes-native distributed inference serving stack**.
-
-As of `v0.7.0` on **2026-05-12**, the official release and architecture materials show a fairly complete stack:
+As of `v0.7.0` on **2026-05-12**, the public release notes and architecture docs show a fairly complete direction:
 
 - Router and Scheduler as first-class components
 - KV cache aware routing
 - Prefill/Decode disaggregation
-- `LeaderWorkerSet` as a multi-node orchestration path
+- `LeaderWorkerSet` as one multi-node orchestration path
 - variant autoscaling
 - integration with the Gateway API inference extension
-- a more explicit `SGLang` path in the official guides
+- a clearer `SGLang` support path
 
-Its value is fundamentally about **cluster-wide intelligence**, not just making one runtime pod faster:
+Its emphasis is cluster-level intelligence rather than only runtime-level throughput:
 
 - whether requests preserve prefix-cache locality
 - whether prefill and decode land in the right resource pools
-- whether the router can make better endpoint choices than generic load balancing
-- whether tail latency and GPU utilization remain sane under large-model and multi-tenant pressure
+- whether routing can make finer endpoint choices than generic load balancing
+- whether tail latency and GPU utilization remain stable under large-model and multi-tenant pressure
 
-If you already know you need:
+## 5. vLLM Production Stack
 
-- cluster-wide cache-aware routing
-- role-aware or PD-aware serving
-- stronger serving intelligence than `vLLM + Service`
+`vLLM Production Stack` is currently closer to an **upstream reference deployment stack**. The official README describes it as **vLLM’s reference system for K8S-native cluster-wide deployment**.
 
-then `llm-d` is one of the clearest options available today.
-
-## 5. vLLM Production Stack: a lighter upstream reference stack
-
-`vLLM Production Stack` should not be understood on the same layer as `llm-d`, `KServe`, or `Dynamo`. Its official README is more modest and more honest: it is **vLLM’s reference system for K8S-native cluster-wide deployment**.
-
-As of `2026-05-07`, the latest release is `vllm-stack-0.1.11`. The current public shape is centered around:
+As of `2026-05-07`, the latest release is `vllm-stack-0.1.11`. Its current public shape centers on:
 
 - Helm-based deployment
 - a request router
 - Prometheus + Grafana observability
 - LMCache / KV cache offloading
-- scaling from a single vLLM instance to distributed vLLM without changing application code
+- a reference path from a single vLLM instance to cluster-wide deployment
 
-That makes it attractive in a specific way:
+The current profile is straightforward:
 
-- it is the most natural option for teams already standardized on `vLLM`
-- it is thinner and closer to an upstream reference deployment than to a full platform
-- it gives you routing, observability, and cache offloading without forcing a larger control-plane adoption up front
+- closer to upstream `vLLM`
+- thinner as a stack
+- already includes a usable baseline for routing, observability, and cache offloading
 
-Its boundary is equally clear:
+At the same time, it does not aim to act as a unified control plane or offer the governance surface associated with `KServe / AIBrix / Kthena / Dynamo`.
 
-- it is not a unified control plane
-- it does not aim to provide the governance surface of `KServe / AIBrix / Kthena / Dynamo`
-- it is better viewed as a practical starting point than as the final answer to every multi-role orchestration problem
+## 6. SGLang, RBG, and LWS/DisaggregatedSet
 
-If your question is simply “how do I run an upstream-style vLLM cluster on Kubernetes cleanly?”, this is a very reasonable first stop.
+This group spans runtime, gateway, and workload-primitive concerns.
 
-## 6. SGLang and RBG: keep runtime/gateway and workload API separate
+### 6.1 SGLang
 
-These two are often mentioned together, but they solve different layers.
+SGLang currently spans both runtime and gateway concerns. Public documentation and releases show a broader surface:
 
-### 6.1 SGLang: a high-performance runtime with an increasingly capable Model Gateway
+- a high-performance serving framework
+- PD disaggregation, HiCache, multiple parallelism modes, and broad hardware support
+- `SGLang Model Gateway`, covering HTTP/gRPC/OpenAI-compatible routing, Kubernetes service discovery, PD topologies, observability, and reliability controls
+- `Unified Inference Gateway Mode`
 
-The current SGLang documentation emphasizes two things at once:
+The current picture is therefore:
 
-- SGLang is a high-performance serving framework with PD disaggregation, HiCache, multiple parallelism modes, and broad hardware coverage
-- SGLang now also has a `Model Gateway` that handles HTTP/gRPC/OpenAI-compatible routing, Kubernetes service discovery, PD topologies, observability, and reliability controls
+- strong runtime capability
+- a growing serving-stack and gateway story
 
-As of `v0.5.11` on **2026-05-05**, one especially important signal is the continued push toward **Unified Inference Gateway Mode**. That means SGLang is no longer only a runtime. It is also becoming a more complete serving entry point.
+### 6.2 RBG
 
-If your team is already committed to SGLang, the first decision is often not “which platform should replace it?” but rather:
+`RBG` is not primarily about gateway behavior. Its core value lies in `RoleBasedGroup` as a multi-role Kubernetes workload API.
 
-- use `SGLang` as the runtime
-- use `SGLang Model Gateway` to extend it into a manageable fleet entry point
-
-### 6.2 RBG: a multi-role workload primitive
-
-`RBG` does not compete with a gateway. Its value is in `RoleBasedGroup` as a Kubernetes workload API for tightly coordinated distributed inference services.
-
-Its README explicitly highlights:
+Its README highlights:
 
 - role startup-order dependencies
 - automated service discovery
@@ -199,56 +182,64 @@ Its README explicitly highlights:
 - atomic rollout
 - topology-aware placement
 - atomic failure recovery
-- support for multiple role backends, including `StatefulSet`, `Deployment`, and `LeaderWorkerSet`
+- multiple role backends, including `StatefulSet`, `Deployment`, and `LeaderWorkerSet`
 
-So the cleaner mental model is:
+That makes `RBG` mainly valuable as a more natural Kubernetes primitive for distributed multi-role inference services.
 
-- `SGLang` solves runtime and gateway
-- `RBG` solves how a multi-role inference service is expressed and orchestrated on Kubernetes
+### 6.3 LWS / DisaggregatedSet
 
-If you are already on `SGLang` and feel that plain `Deployment` or `StatefulSet` is too weak for multi-role serving, `RBG` becomes relevant very quickly.
+`DisaggregatedSet` is a new CRD proposed in the `LeaderWorkerSet` project. Its purpose is to collapse what would otherwise be several manually coordinated `LeaderWorkerSet` objects into one resource.
 
-## 7. AIBrix: a modular GenAI infrastructure platform
+The current KEP-766 draft focuses on a small but important set of problems:
 
-`AIBrix` is increasingly best understood as a **modular platform**, not a single CRD.
+- how multiple LWS instances are upgraded together
+- how version consistency across roles is enforced
+- how revision-aware Services are created automatically
+- how multi-role rollout avoids orphaned workloads and configuration drift
 
-As of `v0.6.0` on **2026-03-03** and the latest official documentation, several signals are clear:
+Several design points stand out:
 
-- vanilla Kubernetes is a first-class deployment path
+- **`spec.roles`**: each role embeds a full `LeaderWorkerSetTemplateSpec`
+- **N-dimensional coordinated rolling update**: roles advance through rollout as one coordinated revision, not as unrelated updates
+- **per-revision headless Services**: names like `{name}-{revision}-{role}-prv` provide the basis for revision-aware traffic routing by upper-layer systems such as `llm-d`
+- **current scope limits**: no HPA/VPA, no multi-cluster support, and no non-LWS backend support in the current draft
+
+Placed next to `RBG`, the difference is fairly clear:
+
+- `RBG` is more general and can use non-LWS backends
+- `DisaggregatedSet` is more explicitly rooted in the LWS ecosystem and focused on coordinated multi-LWS rollout and service orchestration
+
+## 7. AIBrix
+
+`AIBrix` presents a modular platform rather than a single-CRD design.
+
+As of `v0.6.0` on **2026-03-03** and the latest public docs, the main signals are:
+
+- vanilla Kubernetes is a first-class path
 - `Envoy Gateway` is a required entry layer
-- `KubeRay` is optional
-- `StormService` is a main orchestration path for multi-node inference
-- router, KV cache, pod autoscaler, and LoRA-related components all evolve as distinct platform modules
+- `KubeRay` is now optional
+- `StormService` is one main orchestration path for multi-node inference
+- router, KV cache, pod autoscaler, and LoRA/adapter-related capabilities evolve as distinct platform modules
 
-`StormService` itself matters because it is not just a prefill/decode template. It is designed as a three-layer architecture:
+`StormService` matters because it is not merely a PD template. It is structured as:
 
 - `StormService`
 - `RoleSet`
 - `Pods`
 
-and it already supports:
+and its public design already includes:
 
 - replica mode
 - pooled mode
-- top-level rolling and inplace update
-- RoleSet-level parallel, sequential, and interleaved update strategies
+- top-level rolling / inplace update
+- RoleSet-level parallel / sequential / interleaved update
+- role-level autoscaling in pooled mode
 
-More importantly, the current autoscaling docs explicitly describe **role-level autoscaling in pooled mode**. That is a stronger signal than simply saying “supports PD,” because it reaches the real systems problem: different roles have different load signatures and should not always scale as a single unit.
+## 8. Kthena
 
-If your preference is:
+Kthena explicitly presents itself as a **Kubernetes-native AI serving platform**.
 
-- vanilla Kubernetes
-- a composable platform
-- router, autoscaler, KV, and LoRA management as platform capabilities
-- avoiding deep dependence on either `Volcano` or NVIDIA’s full stack
-
-then `AIBrix` is a strong candidate.
-
-## 8. Kthena: a Volcano-native inference control plane
-
-Kthena is no longer a small side effort near Volcano. The `v0.4.0` documentation defines it directly as a **Kubernetes-native AI serving platform**.
-
-Its current value is not just “it also supports PD.” It is that it organizes the following into a coherent service-oriented platform model:
+Its main value is not support for one specific workload shape, but rather the way it organizes a set of platform abstractions:
 
 - `ModelBooster`
 - `ModelRoute`
@@ -257,31 +248,24 @@ Its current value is not just “it also supports PD.” It is that it organizes
 - `AutoScalingPolicy`
 - `AutoScalingPolicyBinding`
 
-From the current docs and official launch blog, its strengths are clear:
+From the current docs and official blog, several characteristics are stable:
 
-- native affinity with the `Volcano` scheduling ecosystem
+- strong affinity with the `Volcano` scheduling ecosystem
 - multi-backend support across `vLLM`, `SGLang`, `Triton`, and `TorchServe`
 - request-level intelligent routing
-- token-based rate limiting, canaries, and failover
+- token-based rate limiting, canary, and failover
 - role-aware PD routing
 - multi-metric, cost-driven autoscaling
 
-Another important evolution is Kthena’s posture toward LWS. Its public proposal and follow-up PRs show that it is not rejecting `LeaderWorkerSet`. Instead, it is exploring **LWS API compatibility**, treating LWS as one possible northbound interface rather than as the only internal primitive.
+At the same time, public proposals and follow-up PRs show ongoing exploration of **LWS API compatibility**. That places LWS more as a compatible northbound interface than as the only internal primitive.
 
-If you already stand on:
+## 9. Dynamo
 
-- `Volcano`
-- gang scheduling
-- topology-aware placement
-- heterogeneous accelerator orchestration
+`Dynamo` is currently best understood as a **performance-system-first inference platform**.
 
-then Kthena is often the most native-feeling answer.
+The official documentation presents it as a broader stack:
 
-## 9. Dynamo: a performance-system-first inference platform
-
-Dynamo should not be reduced to “an orchestrator.” Its official docs clearly show a broader stack:
-
-- `DynamoGraphDeploymentRequest (DGDR)`: the recommended simplified, SLA-driven entry point
+- `DynamoGraphDeploymentRequest (DGDR)`: the recommended simplified SLA-driven entry point
 - `DynamoGraphDeployment (DGD)`: a more direct low-level deployment path
 - `Planner`
 - `Profiler`
@@ -289,154 +273,95 @@ Dynamo should not be reduced to “an orchestrator.” Its official docs clearly
 - `KVBM`
 - multi-node orchestration through `Grove`
 
-The Kubernetes deployment guide and Grove documentation make the current direction explicit:
+The Kubernetes deployment guide and Grove documentation point in a clear direction:
 
-- the platform layer is centered on `DGDR/DGD + Operator`
-- multi-node, multi-role orchestration is primarily handled through `Grove`
-- `Planner` helps turn SLA intent into deployment shape and scaling decisions
+- the platform layer is carried by `DGDR/DGD + Operator`
+- multi-node and multi-role orchestration is mainly delegated to `Grove`
+- `Planner` translates SLA intent into deployment shape and scaling behavior
 
-`Grove` is especially important because it publicly frames itself as:
+`Grove` itself emphasizes:
 
-- a Kubernetes API designed for modern AI workloads, especially disaggregated inference
-- a unified way to express prefill, decode, routing, and other components inside one resource
-- a path for multi-level horizontal autoscaling, startup dependencies, and topology-aware scheduling
+- a Kubernetes API for modern AI workloads, especially disaggregated inference
+- a unified resource that can express prefill, decode, routing, and related components
+- support for multi-level horizontal autoscaling, startup dependencies, and topology-aware scheduling
 
-So the more accurate statement today is not “Dynamo has a Grove mode and an LWS mode.” It is:
+## 10. Comparison
 
-Dynamo has assembled a broader performance-oriented platform, and `Grove` is the key Kubernetes orchestration path for its multi-role, multi-node serving story.
-
-If your environment is primarily:
-
-- `NVIDIA`
-- large-model and multi-node
-- strongly SLA-driven
-- interested in profiler/planner/backend/KV-path optimization as one system
-
-then `Dynamo` remains especially compelling.
-
-## 10. A more useful comparison table
-
-| Option | Real role | `role / PD` support | Routing / gateway | Scaling | Ecosystem center of gravity |
+| Option | Positioning | `role / PD` | Routing / gateway | Scaling | Ecosystem center of gravity |
 | --- | --- | --- | --- | --- | --- |
-| `KServe` | Unified AI inference platform | Strong, exposed through `LLMInferenceService` | Strong | Strong | Standard Kubernetes platform teams |
+| `KServe` | Unified AI inference platform | Strong, exposed through `LLMInferenceService` | Strong | Strong | Standard Kubernetes platform |
 | `llm-d` | Distributed serving stack | Very strong | Very strong | Strong | High-performance distributed LLM serving |
-| `vLLM Production Stack` | Upstream reference stack | Present but not its most distinctive selling point | Medium to strong | Medium | Pure `vLLM` users |
-| `SGLang` | Runtime + gateway | Very strong | Very strong | Medium to strong | `SGLang` runtime users |
-| `RBG` | Multi-role workload API | Core capability | Primarily service discovery | Strong | Teams needing a generic multi-role primitive |
-| `AIBrix` | Modular GenAI infrastructure platform | Very strong, especially via `StormService / RoleSet` | Strong | Strong, including role-level autoscaling | Vanilla Kubernetes + platform composition |
-| `Kthena` | Volcano-native AI serving platform | Very strong, especially via `ModelServing / ServingGroup / Role` | Very strong | Very strong | Volcano / scheduling and topology first |
-| `Dynamo` | Performance-first AI infrastructure platform | Very strong, especially via `DGDR/DGD + Grove` | Very strong | Very strong, with planner emphasis | NVIDIA / multi-node / SLA-driven teams |
+| `vLLM Production Stack` | Upstream reference stack | Present, but not the most distinctive current selling point | Medium to strong | Medium | Pure `vLLM` ecosystem |
+| `SGLang` | Runtime + gateway | Very strong | Very strong | Medium to strong | `SGLang` runtime and gateway |
+| `RBG` | Multi-role workload API | Core capability | Mostly service discovery | Strong | Generic multi-role primitive |
+| `LWS / DisaggregatedSet` | Multi-role primitive on top of LWS | Very strong | Mainly revision-aware Service orchestration | More conservative scaling scope in the current draft | LWS ecosystem |
+| `AIBrix` | Modular GenAI infrastructure platform | Very strong, with `StormService / RoleSet` already fairly mature | Strong | Strong, including public role-level autoscaling | Vanilla Kubernetes + platform modules |
+| `Kthena` | Volcano-native AI serving platform | Very strong, with `ModelServing / ServingGroup / Role` | Very strong | Very strong | Volcano / scheduling and topology |
+| `Dynamo` | Performance-first AI infrastructure platform | Very strong, especially through `DGDR/DGD + Grove` | Very strong | Very strong, with explicit planner emphasis | NVIDIA / multi-node / SLA |
 
-## 11. How to choose based on your existing infrastructure
+## 11. Scenario view
 
-The matrix below is intentionally simplified. In real deployments you still need to account for model size, GPU generation, network topology, cost model, platform-team maturity, and multi-tenant boundaries.
+The cases below are intentionally simplified. The aim is to show ecosystem and infrastructure alignment, not to rank the projects abstractly.
 
-### If you are already a Volcano user
+### Volcano environments
 
-Start with `Kthena`.
+`Kthena` sits closest to the `Volcano` scheduling and platform model. Gang scheduling, topology-aware placement, and inference role orchestration can be understood in one ecosystem.
 
-The point is not just that it supports inference. The point is that it keeps:
+### KServe environments
 
-- gang scheduling
-- topology-aware scheduling
-- role-aware inference orchestration
-- route/scale/policy control
+`KServe + llm-d` is currently the most natural public combination: the former provides the platform entry point and governance layer, while the latter provides the distributed serving layer.
 
-inside one ecosystem.
+### vLLM environments
 
-### If you are already a KServe user
+`vLLM Production Stack` fits the lighter upstream deployment path. `llm-d` fits the cases where cluster-wide routing, KV locality, and PD orchestration become central concerns.
 
-Start with `KServe + llm-d`, not “KServe or llm-d.”
+### NVIDIA-oriented environments
 
-`KServe` is the control plane. `llm-d` is the distributed serving intelligence. For teams already built around `InferenceService`, Gateway API, and platform governance, this is usually the cleanest next step.
+`Dynamo` together with `Grove` places more emphasis on an integrated path across profiler, planner, backend behavior, KV handling, and multi-node orchestration.
 
-### If you are primarily a vLLM shop
+### Vanilla Kubernetes environments
 
-Decide whether you want the lightest path or the most capable serving stack:
+`AIBrix` currently presents the clearest platform-modularization path. `Envoy Gateway`, `StormService`, `Router`, `PodAutoscaler`, and `KV Cache` form a relatively complete control-plane story.
 
-- if you want an upstream-style reference deployment first, choose `vLLM Production Stack`
-- if you already know you need cache-aware routing, PD, and cluster-level serving intelligence, choose `llm-d`
+### SGLang environments
 
-### If you are primarily an NVIDIA shop
+`SGLang` and `RBG` are more naturally upstream/downstream complements: the former covers runtime and gateway, while the latter covers the multi-role workload API.
 
-Start with `Dynamo`, especially if you care about:
+### Upstream primitive path
 
-- multi-node large-model serving
-- strong SLA-driven deployment behavior
-- using profiler and planner to guide deployment shape
-- joint optimization across backend, KV, routing, and orchestration layers
+`RBG` and `LWS/DisaggregatedSet` point to two different directions in upstream workload-primitive work:
 
-### If you are a vanilla Kubernetes platform team
+- `RBG` is more general
+- `DisaggregatedSet` is more focused on coordinated multi-role rollout and service orchestration inside the LWS ecosystem
 
-Start with `AIBrix`.
+## 12. The boundary of PD disaggregation
 
-Its current balance between platform modularity and limited scheduler lock-in is clear. It gives you a natural way to compose:
+PD disaggregation is part of a broader systems design question. Even so, support for PD does not imply that PD is a good fit in every environment.
 
-- `Envoy Gateway`
-- `StormService`
-- `Router`
-- `PodAutoscaler`
-- `KV Cache`
-
-without requiring a full shift into either `Volcano` or NVIDIA’s broader stack.
-
-### If you are an SGLang team
-
-The usual progression is:
-
-1. `SGLang runtime`
-2. `SGLang Model Gateway`
-3. add `RBG` only if you also need a stronger Kubernetes multi-role workload API
-
-In other words, `SGLang` and `RBG` are often complementary rather than substitutes.
-
-### If you want the most upstream-style primitive path
-
-Pay closer attention to:
-
-- `RBG`
-- `LWS + DisaggregatedSet`
-
-These matter more as workload APIs than as full inference platforms.
-
-## 12. PD disaggregation is still not the default answer
-
-This point remains true.
-
-Even though nearly every major direction now strengthens `prefill/decode` separation, supporting PD does not mean PD is automatically worth the operational and systems complexity.
-
-PD tends to make the most sense when:
+It tends to make the most sense when:
 
 - prompts are long and outputs are relatively short
 - concurrency is high and request shapes vary widely
-- prefill and decode prefer different hardware or different resource pools
-- you truly need to optimize `TTFT` and `TPOT` separately
+- prefill and decode prefer meaningfully different hardware or resource pools
+- `TTFT` and `TPOT` need to be optimized independently
 
-You should be more cautious when:
+It deserves more caution when:
 
 - contexts are short or models are small to medium
 - concurrency is low
 - hardware is homogeneous
 - KV transfer and cross-role coordination may erase the gains
-- your team does not yet have the observability and operational maturity to support the added moving parts
-
-The real progress today is that platforms are turning PD from a lab technique into an operable system capability. It is still not a free win.
+- platform observability, routing, and failure handling are not yet mature enough
 
 ## Conclusion
 
-As of `2026-05-13`, the main story is no longer “who supports PD.” It is “who can turn role-aware orchestration, routing, autoscaling, topology, and failure handling into a system that teams can actually run.”
+As of `2026-05-13`, a practical comparison starts with the layer of the inference system each project is addressing.
 
-So the real decision is not only “AIBrix or Kthena or Dynamo.” It is:
+From that perspective:
 
-- are you choosing a **runtime**, a **serving stack**, a **platform**, or a **workload API**
-- do you care more about **ecosystem compatibility** or **performance-system capability**
-- do you want to stay close to **upstream generic abstractions** or accept deeper alignment with a stronger ecosystem-specific stack
+- `vLLM` and `SGLang` are mainly runtimes
+- `vLLM Production Stack` and `llm-d` are mainly serving stacks
+- `KServe`, `AIBrix`, `Kthena`, and `Dynamo` are mainly platforms
+- `RBG` and `LWS/DisaggregatedSet` are mainly workload primitives
 
-If you only keep one line:
-
-- want a modular platform: `AIBrix`
-- want a Volcano-native inference control plane: `Kthena`
-- want a performance-system-first path, especially for NVIDIA: `Dynamo`
-- want high-performance distributed serving on Kubernetes: `llm-d`
-- want the lightest upstream-style vLLM deployment path first: `vLLM Production Stack`
-- already live in the SGLang world: `SGLang Gateway + RBG`
+Separating the layers makes the roles, boundaries, and composition paths among these projects clearer.

--- a/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks_zh.md
+++ b/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks_zh.md
@@ -1,0 +1,437 @@
+---
+status: Active
+maintainer: pacoxu
+date: 2026-05-13
+tags: inference, orchestration, kubernetes, llm, pd-disaggregation, llm-d, kserve, dynamo, aibrix, kthena, sglang, rbg, vllm
+canonical_path: docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks_zh.md
+source_urls:
+  - https://kserve.github.io/website/
+  - https://kserve.github.io/website/docs/model-serving/generative-inference/llmisvc/llmisvc-overview
+  - https://kserve.github.io/website/docs/model-serving/generative-inference/llmisvc/llmisvc-envoy-ai-gateway
+  - https://kserve.github.io/website/blog/cloud-native-ai-inference-kserve-llm-d
+  - https://github.com/llm-d/llm-d
+  - https://github.com/llm-d/llm-d/releases
+  - https://llm-d.ai/docs/architecture/architecture
+  - https://github.com/vllm-project/production-stack
+  - https://github.com/vllm-project/production-stack/releases
+  - https://docs.vllm.ai/en/latest/deployment/integrations/production-stack.html
+  - https://github.com/vllm-project/aibrix
+  - https://github.com/vllm-project/aibrix/releases
+  - https://aibrix.readthedocs.io/latest/getting_started/installation/installation.html
+  - https://aibrix.readthedocs.io/latest/designs/aibrix-stormservice.html
+  - https://aibrix.readthedocs.io/latest/designs/aibrix-router.html
+  - https://aibrix.readthedocs.io/latest/features/autoscaling/metric-based-autoscaling.html
+  - https://kthena.volcano.sh/docs/intro
+  - https://kthena.volcano.sh/docs/v0.2.0/architecture
+  - https://github.com/volcano-sh/kthena/blob/main/docs/proposal/modelserving-role-support-leaderworkerset.md
+  - https://github.com/volcano-sh/kthena/pull/767
+  - https://volcano.sh/en/blog/introducing-kthena-redefining-llm-inference-for-the-cloud-native-era/
+  - https://docs.nvidia.com/dynamo/latest/kubernetes-deployment/deployment-guide
+  - https://docs.nvidia.com/dynamo/latest/kubernetes-deployment/multinode/grove
+  - https://docs.nvidia.com/dynamo/components/planner/planner-guide
+  - https://github.com/ai-dynamo/dynamo
+  - https://docs.sglang.io/
+  - https://docs.sglang.io/advanced_features/router.html
+  - https://github.com/sgl-project/sglang/releases
+  - https://github.com/sgl-project/rbg
+  - https://github.com/kubernetes-sigs/lws/blob/main/keps/766-DisaggregatedSet/README.md
+---
+
+# 推理编排方案如何选择？AIBrix、Kthena、Dynamo、llm-d、KServe、vLLM Production Stack 与 SGLang/RBG
+
+本文基于截至 **2026-05-13** 的公开资料，仅用于技术参考。不同方案的实际效果高度依赖业务负载、GPU 与网络拓扑、现有控制面、团队运维能力与生态绑定方式。项目当前设计不代表最终形态，社区开放度、活跃度和与上游生态的融合方向，通常比单个版本里的功能表更重要。
+
+## 先说结论
+
+今天做推理编排选型，最容易犯的错误不是“选错项目”，而是把**不同层的东西拿来横向比较**：
+
+- `vLLM`、`SGLang` 更接近 **runtime / 推理引擎**
+- `vLLM Production Stack`、`llm-d` 更接近 **serving stack**
+- `KServe`、`AIBrix`、`Kthena`、`Dynamo` 更接近 **平台 / control plane**
+- `RBG`、`LWS/DisaggregatedSet` 更接近 **workload primitive / 编排 API**
+
+如果只给一句最短建议：
+
+- 已经深度使用 `Volcano`：优先看 `Kthena`
+- 已经标准化 `KServe`：优先看 `KServe + llm-d`
+- 纯 `vLLM` 团队且想先上最轻一层：优先看 `vLLM Production Stack`
+- 以 `NVIDIA` 集群和性能系统能力为第一优先级：优先看 `Dynamo`
+- 希望在 vanilla Kubernetes 上组合平台组件：优先看 `AIBrix`
+- 已经以 `SGLang` 为 runtime：优先看 `SGLang Model Gateway`；如果还要 Kubernetes 上的一等多角色 workload API，再看 `RBG`
+
+## 1. 过去一年最大的变化
+
+2025 年这个话题常被讲成“大家都在做 PD 分离”。到 2026 年，这个说法已经不够用了。当前的主线更准确地说是：
+
+- 不是只解决“怎么起 Pod”，而是解决 **role-aware orchestration**
+- 不是只做 prefill/decode，而是把 **routing、KV、autoscaling、topology、failure handling** 一起纳入系统设计
+- 不是只选一个 CRD，而是在选一套 **runtime + serving + control plane + scheduling** 的组合
+
+几个旧印象已经需要更新：
+
+- `AIBrix` 不再是 “KubeRay 用户的方案”。官方安装文档已经明确：`KubeRay` 是可选组件，不装也能用 `StormService` 跑单机和多节点推理。
+- `Dynamo` 也不适合再简单概括成 “Grove 模式或 LWS 模式”。它已经形成了 `DGDR/DGD + Operator + Planner + Grove` 的 Kubernetes 路线。
+- `KServe` 与 `llm-d` 也不宜再理解成互斥关系。`KServe 0.17` 文档已经明确写出 `LLMInferenceService` built on `llm-d`。
+- `SGLang` 不只是 runtime。最新文档里的 `Model Gateway` 已经覆盖路由、Kubernetes service discovery、PD topology、可靠性控制和 Inference Gateway Mode。
+
+## 2. 先按层来拆，而不是按名字比
+
+| 层次 | 代表项目 | 更像什么 |
+| --- | --- | --- |
+| Runtime / 引擎 | `vLLM`、`SGLang` | 在单 Pod 或多 Pod 内执行推理 |
+| Serving Stack | `vLLM Production Stack`、`llm-d` | 把 runtime 扩展成可部署、可路由、可观测的集群级服务 |
+| Platform / Control Plane | `KServe`、`AIBrix`、`Kthena`、`Dynamo` | 用 CRD、router、autoscaler、policy 去统一管理推理生命周期 |
+| Workload Primitive | `RBG`、`LWS/DisaggregatedSet` | 为多角色、多节点、强协作 workload 提供更合适的 Kubernetes API |
+
+这个分层视角会直接影响你的选型逻辑：
+
+- 如果你在找的是“统一入口和治理能力”，就应该优先比较 `KServe / AIBrix / Kthena / Dynamo`
+- 如果你在找的是“高性能分布式 serving 方案”，重点应放在 `llm-d / vLLM Production Stack / SGLang Gateway`
+- 如果你在找的是“多角色 workload API”，那就更该看 `RBG / LWS / DisaggregatedSet`
+
+## 3. KServe：更像统一 AI 推理平台，而不是单一 runtime 包装器
+
+截至 `2026-05-13`，KServe 官网已经把自己定位成 **Standardized Distributed Generative and Predictive AI Inference Platform**。它当前最重要的变化不是“能跑 LLM 了”，而是把 Generative 路线单独做成了 `LLMInferenceService`。
+
+从官方 `0.17` 文档看，`LLMInferenceService` 的关键信号非常明确：
+
+- 它是面向 Generative AI 的独立 CRD，不再把 LLM 只塞进传统 `InferenceService`
+- 它直接建立在 `llm-d` 之上
+- 它在平台层暴露了多节点、PD 分离、Advanced Routing、DP+EP 等能力
+- 它同时保留了 KServe 一贯擅长的统一 API、生命周期管理、Gateway API 集成和企业运维治理
+
+这意味着，今天很多场景下你不该再问 “KServe or llm-d”，而更应该问：
+
+`KServe` 是否是我想要的控制面，`llm-d` 是否是我愿意接受的底层 distributed serving stack？
+
+如果你已经有：
+
+- `Knative/KServe` 经验
+- 标准 Kubernetes API 驱动的模型交付流程
+- 统一流量入口、配额、网关策略、团队边界
+
+那么 `KServe + llm-d` 往往是最自然的组合。
+
+## 4. llm-d：高性能 distributed serving stack
+
+`llm-d` 的位置越来越清楚了。它不是通用平台，也不是单纯的 vLLM deployment 模板，而是一个 **Kubernetes-native distributed inference serving stack**。
+
+截至 `2026-05-12` 发布的 `v0.7.0`，官方 release 和文档显示它的核心能力已经比较完整：
+
+- Router / Scheduler 作为一等组件
+- KV cache aware routing
+- Prefill/Decode disaggregation
+- LeaderWorkerSet 作为多节点编排路径之一
+- variant autoscaler
+- 与 Gateway API inference extension 的整合
+- 新增更完整的 `SGLang` well-lit path
+
+它的价值主要在“集群级智能”，而不是“单 Pod 里把 kernel 跑得更快”：
+
+- 请求是否命中前缀缓存
+- prefill 和 decode 是否落在最合适的资源池
+- router 是否能做更细粒度 endpoint 选择
+- 多租户和大模型场景下的 tail latency 与 GPU 利用率如何控制
+
+如果你已经认定：
+
+- 需要 cluster-wide cache aware routing
+- 需要 role-aware / PD-aware serving
+- 需要比 `vLLM + Service` 更强的集群级调度智能
+
+那么 `llm-d` 是目前最清晰的一条路线之一。
+
+## 5. vLLM Production Stack：更轻的 upstream reference stack
+
+`vLLM Production Stack` 不应和 `llm-d`、`KServe`、`Dynamo` 放在同一层理解。它在官方 README 中的定位更朴素：**vLLM’s reference system for K8S-native cluster-wide deployment**。
+
+截至 `2026-05-07`，最新 release 是 `vllm-stack-0.1.11`。当前公开形态的重点是：
+
+- Helm 驱动的部署方式
+- request router
+- Prometheus + Grafana observability
+- LMCache / KV cache offloading
+- 在不改应用代码的前提下，从单实例扩到分布式 vLLM
+
+这条路线的优点很明确：
+
+- 对已经标准化 `vLLM` 的团队最友好
+- 栈更薄，更像 reference stack 而不是完整平台
+- 能较快落地基础的路由、观测和 cache offloading
+
+它的边界也同样明确：
+
+- 它不是统一 control plane
+- 它不试图提供 `KServe / AIBrix / Kthena / Dynamo` 那样的完整平台治理能力
+- 它更适合作为“先用起来”的起点，而不是“一次性解决所有多角色编排问题”的终点
+
+如果你只想回答“如何更稳妥地在 Kubernetes 上部署一套 upstream vLLM 集群”，那它是很合理的第一站。
+
+## 6. SGLang 与 RBG：runtime/gateway 和 workload API 要分开看
+
+这两者最容易被混成一个东西，但实际上不是同一层。
+
+### 6.1 SGLang：高性能 runtime，外加越来越完整的 Model Gateway
+
+SGLang 官方文档当前已经同时强调两件事：
+
+- 它本身是高性能 serving framework，支持 PD disaggregation、HiCache、多种并行方式、广泛硬件平台
+- 它现在还有 `SGLang Model Gateway`，提供 HTTP/gRPC/OpenAI-compatible 路由、Kubernetes service discovery、PD topology、可靠性控制、观测与 Inference Gateway Mode
+
+截至 `2026-05-05` 的 `v0.5.11` release，SGLang 又强化了一个重要方向：**统一 Inference Gateway Mode**。这意味着它不仅是一个 runtime，也越来越像“自带 gateway 的 serving stack”。
+
+所以，如果你的团队已经明确站在 `SGLang` 路线上，第一选择往往不是“换个平台”，而是：
+
+- 先用 `SGLang runtime`
+- 再用 `SGLang Model Gateway` 扩展成可运维的集群入口
+
+### 6.2 RBG：多角色 workload primitive
+
+`RBG` 的价值不在于当 gateway，而在于提供 `RoleBasedGroup` 这种更适合分布式推理服务的 Kubernetes workload API。
+
+它 README 里公开强调的点包括：
+
+- role startup-order dependencies
+- auto service discovery
+- group/role 级 elastic scaling
+- atomic rollout
+- topology-aware placement
+- atomic failure recovery
+- 可定制 workload backend，包括 `StatefulSet`、`Deployment`、`LeaderWorkerSet`
+
+所以更准确的定位是：
+
+- `SGLang` 解决 runtime 和 gateway
+- `RBG` 解决多角色 workload 如何在 Kubernetes 上被表达和编排
+
+如果你是 `SGLang` 用户，又觉得 `Deployment/StatefulSet` 对多角色服务表达不够好，`RBG` 就值得重点看。
+
+## 7. AIBrix：模块化的 GenAI 基础设施平台
+
+`AIBrix` 当前更像“模块化平台”，而不是单一 CRD。
+
+截至 `2026-03-03` 的 `v0.6.0` 与最新文档，几个信号已经很明确：
+
+- 官方安装文档明确支持 vanilla Kubernetes
+- `Envoy Gateway` 是前置依赖
+- `KubeRay` 变成可选组件
+- `StormService` 是其多节点编排主线之一
+- `Router`、`KV cache`、`PodAutoscaler`、`LoRA/Adapter` 等能力都在平台内独立演进
+
+`StormService` 的价值在于，它不是单纯的 prefill/decode 模板，而是明确设计成三层结构：
+
+- `StormService`
+- `RoleSet`
+- `Pods`
+
+并且它同时支持：
+
+- replica mode
+- pooled mode
+- top-level rolling / inplace update
+- RoleSet 级 parallel / sequential / interleaved update
+
+更重要的是，AIBrix 当前文档已经明确支持 pooled mode 下的 **role-level autoscaling**。这一点和很多只会说“支持 PD”的项目相比，工程含义更大，因为它真正触及了不同 role 负载形状不同这一现实。
+
+如果你的偏好是：
+
+- vanilla Kubernetes
+- 组件化平台
+- Router、Autoscaler、KV、LoRA 都希望是平台一部分
+- 不想深度绑定 `Volcano` 或 NVIDIA 自家整栈
+
+那么 `AIBrix` 是很强的候选。
+
+## 8. Kthena：Volcano 原生的完整推理控制面
+
+Kthena 到现在已经不是一个“Volcano 旁边的实验项目”了。`v0.4.0` 官方文档把它定义得很直接：**Kubernetes-native AI serving platform**。
+
+它当前的特点，不是“也支持 PD”，而是把下面这些能力组织到了一套面向服务的平台抽象里：
+
+- `ModelBooster`
+- `ModelRoute`
+- `ModelServer`
+- `ModelServing`
+- `AutoScalingPolicy`
+- `AutoScalingPolicyBinding`
+
+从当前文档和官方博客看，Kthena 的强项在于：
+
+- 与 `Volcano` 调度生态天然亲和
+- 面向多后端引擎，包括 `vLLM`、`SGLang`、`Triton`、`TorchServe`
+- request-level intelligent routing
+- token-based rate limit、canary、failover
+- role-aware PD routing
+- 多指标、成本驱动 autoscaling
+
+另外，Kthena 的一个重要变化是它对 LWS 的态度。公开 proposal 与后续 PR 说明，它并不是排斥 `LeaderWorkerSet`，而是在探索 **LWS API compatibility**，把 LWS 视作一个可兼容的 northbound 接口，而不是唯一底层 primitive。
+
+这意味着如果你已经站在：
+
+- `Volcano`
+- gang scheduling
+- topology-aware placement
+- heterogenous accelerator orchestration
+
+这一侧，那么 Kthena 往往比其他方案更“原生”。
+
+## 9. Dynamo：性能系统优先的推理平台
+
+`Dynamo` 现在最不应该被简化成“一个编排器”。从官方文档看，它已经明显是一整套平台：
+
+- `DynamoGraphDeploymentRequest (DGDR)`：推荐的、简化的 SLA 驱动入口
+- `DynamoGraphDeployment (DGD)`：更直接的底层配置入口
+- `Planner`
+- `Profiler`
+- `Router`
+- `KVBM`
+- 与 `Grove` 的多节点编排整合
+
+官方 Kubernetes deployment guide 和 Grove 文档显示，Dynamo 当前的思路非常清楚：
+
+- 平台层由 `DGDR/DGD + Operator` 承担
+- 多节点、多角色编排主要交给 `Grove`
+- `Planner` 负责围绕 SLA 生成和调整部署形态
+
+`Grove` 这条线尤其值得注意。它公开把自己定义成：
+
+- 专门为现代 AI workload，特别是 disaggregated inference 设计的 Kubernetes API
+- 能在单个资源中表达 prefill、decode、routing 等多个 component
+- 支持 multi-level horizontal autoscaling、startup dependencies、topology-aware scheduling
+
+所以今天更准确的说法不是 “Dynamo 有 Grove 模式和 LWS 模式”，而是：
+
+`Dynamo` 已经把性能系统、平台入口和 Kubernetes 编排主线组织起来了，而 `Grove` 是其中面向多角色、多节点编排的核心一环。
+
+如果你主要是：
+
+- `NVIDIA` 集群
+- 大模型、多节点、强 SLA 驱动
+- 更在意 profiler / planner / backend / KV 路径的一体化
+
+那么 `Dynamo` 的吸引力仍然最大。
+
+## 10. 一个更有意义的对比表
+
+| 方案 | 本质定位 | `role / PD` | 路由与网关 | 扩缩容 | 生态重心 |
+| --- | --- | --- | --- | --- | --- |
+| `KServe` | 统一 AI inference 平台 | 强，但更多通过 `LLMInferenceService` 暴露 | 强，Gateway API 与 AI Gateway 明确成型 | 强 | 标准 K8s 平台、KServe 用户 |
+| `llm-d` | distributed serving stack | 很强 | 很强 | 强 | 高性能分布式 LLM serving |
+| `vLLM Production Stack` | upstream reference stack | 有，但不是它当前最突出的卖点 | 中到强 | 中 | 纯 `vLLM` 用户 |
+| `SGLang` | runtime + gateway | 很强 | 很强 | 中到强 | `SGLang` runtime 用户 |
+| `RBG` | multirole workload API | 核心能力 | 以 service discovery 为主 | 强 | 需要通用多角色 primitive 的团队 |
+| `AIBrix` | 模块化 GenAI infra 平台 | 很强，`StormService/RoleSet` 已较成熟 | 强 | 强，role-level autoscaling 已落地 | vanilla Kubernetes + 平台组件组合 |
+| `Kthena` | Volcano-native AI serving platform | 很强，`ModelServing/ServingGroup/Role` | 很强 | 很强 | Volcano / 调度与拓扑优先 |
+| `Dynamo` | performance-first AI infra platform | 很强，`DGDR/DGD + Grove` | 很强 | 很强，Planner 能力突出 | NVIDIA / 多节点 / SLA 驱动 |
+
+## 11. 怎么选：按你已有基础设施来
+
+下面给一个简化版决策指南。真实场景里还要考虑模型形态、GPU 代际、网络拓扑、成本模型、平台团队能力和多租户边界。
+
+### 如果你已经是 Volcano 用户
+
+优先看 `Kthena`。
+
+原因不是“它也支持推理”，而是它的调度与平台抽象天然站在同一个生态里。你会更容易把：
+
+- gang scheduling
+- topology-aware scheduling
+- 推理 role 编排
+- route/scale/policy
+
+放进一条统一链路。
+
+### 如果你已经是 KServe 用户
+
+优先看 `KServe + llm-d`，而不是把两者当成二选一。
+
+`KServe` 更像 control plane，`llm-d` 更像 distributed intelligence / serving stack。对于已经围绕 `InferenceService`、Gateway API、平台治理构建流程的团队，这通常是最自然的升级路径。
+
+### 如果你主要是 vLLM 用户
+
+先问自己要的是“最轻方案”还是“最强 serving stack”：
+
+- 想先快速得到一套 upstream 参考部署：`vLLM Production Stack`
+- 已经明确需要 cache-aware routing、PD、cluster-level intelligence：`llm-d`
+
+### 如果你主要是 NVIDIA 集群
+
+优先看 `Dynamo`，尤其是：
+
+- 多节点大模型
+- 强 SLA 驱动
+- 希望用 profiler / planner 来辅助配置选择
+- 希望 route、KV、backend、orchestration 一起优化
+
+### 如果你是 vanilla Kubernetes 团队
+
+优先看 `AIBrix`。
+
+它目前在“平台组件化”和“不过度绑定某个单一调度器”之间的平衡比较清晰。你可以更自然地组合：
+
+- `Envoy Gateway`
+- `StormService`
+- `Router`
+- `PodAutoscaler`
+- `KV Cache`
+
+### 如果你是 SGLang 用户
+
+优先顺序通常是：
+
+1. `SGLang runtime`
+2. `SGLang Model Gateway`
+3. 如果还需要更强的 Kubernetes 多角色 workload API，再补 `RBG`
+
+换句话说，`SGLang` 与 `RBG` 更像上下配合，而不是互相替代。
+
+### 如果你想要更“上游 primitive”的路线
+
+可以重点关注：
+
+- `RBG`
+- `LWS + DisaggregatedSet`
+
+这一层的价值在于 workload API，而不是完整平台。
+
+## 12. PD 分离仍然不是默认答案
+
+这一点到今天依然成立。
+
+虽然这几个方向几乎都在强化 `prefill/decode` 分离，但“支持 PD”不等于“PD 一定值得”。
+
+更适合引入 PD 的情况通常包括：
+
+- 长 prompt、短输出
+- 高并发，且请求形状差异大
+- prefill 与 decode 对硬件偏好明显不同
+- 你确实要单独优化 `TTFT` 与 `TPOT`
+
+更应该谨慎的情况包括：
+
+- 短上下文或中小模型
+- 低并发
+- 同构硬件
+- KV 传输和跨 role 协调成本可能吞掉收益
+- 团队目前还没有足够观测与运维能力
+
+今天的进步主要是：平台终于开始把 PD 从“实验室技巧”做成“可运维能力”。但它仍然不是银弹。
+
+## 结语
+
+截至 `2026-05-13`，这个领域的主线已经不是“谁支持 PD”，而是“谁能把 role-aware orchestration、routing、autoscaling、topology 和 failure handling 组织成一套可落地的系统”。
+
+所以真正要回答的，不只是 “AIBrix or Kthena or Dynamo”，而是：
+
+- 你是在选 **runtime**、**serving stack**、**平台**，还是 **workload API**
+- 你更在意 **生态兼容**，还是 **性能系统能力**
+- 你是想贴近 **上游通用抽象**，还是接受某个生态更强的整栈绑定
+
+如果只保留一句话：
+
+- 想要模块化平台：`AIBrix`
+- 想要 Volcano 原生推理控制面：`Kthena`
+- 想要性能系统优先、尤其是 NVIDIA 路线：`Dynamo`
+- 想要 K8s 上高性能 distributed serving：`llm-d`
+- 想先上最轻的 upstream vLLM 参考栈：`vLLM Production Stack`
+- 已经是 SGLang 体系：`SGLang Gateway + RBG`

--- a/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks_zh.md
+++ b/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks_zh.md
@@ -39,214 +39,209 @@ source_urls:
 
 # 推理编排方案如何选择？AIBrix、Kthena、Dynamo、llm-d、KServe、vLLM Production Stack 与 SGLang/RBG
 
-本文基于截至 **2026-05-13** 的公开资料，仅用于技术参考。不同方案的实际效果高度依赖业务负载、GPU 与网络拓扑、现有控制面、团队运维能力与生态绑定方式。项目当前设计不代表最终形态，社区开放度、活跃度和与上游生态的融合方向，通常比单个版本里的功能表更重要。
+本文基于截至 **2026-05-13** 的公开资料，仅用于技术参考。不同方案的实际效果高度依赖业务负载、GPU 与网络拓扑、现有控制面、运维方式与生态绑定程度。项目当前设计不代表最终形态，社区开放度、活跃度与长期演进方向，通常比单个版本里的功能表更重要。
 
-## 先说结论
+## 摘要
 
-今天做推理编排选型，最容易犯的错误不是“选错项目”，而是把**不同层的东西拿来横向比较**：
+当前公开资料里，这些项目更适合先按层理解，再做横向对比：
 
 - `vLLM`、`SGLang` 更接近 **runtime / 推理引擎**
 - `vLLM Production Stack`、`llm-d` 更接近 **serving stack**
 - `KServe`、`AIBrix`、`Kthena`、`Dynamo` 更接近 **平台 / control plane**
 - `RBG`、`LWS/DisaggregatedSet` 更接近 **workload primitive / 编排 API**
 
-如果只给一句最短建议：
+从当前公开资料看：
 
-- 已经深度使用 `Volcano`：优先看 `Kthena`
-- 已经标准化 `KServe`：优先看 `KServe + llm-d`
-- 纯 `vLLM` 团队且想先上最轻一层：优先看 `vLLM Production Stack`
-- 以 `NVIDIA` 集群和性能系统能力为第一优先级：优先看 `Dynamo`
-- 希望在 vanilla Kubernetes 上组合平台组件：优先看 `AIBrix`
-- 已经以 `SGLang` 为 runtime：优先看 `SGLang Model Gateway`；如果还要 Kubernetes 上的一等多角色 workload API，再看 `RBG`
+- `KServe` 已经把 Generative AI 路线单独落到 `LLMInferenceService`，并明确建立在 `llm-d` 之上
+- `llm-d` 正在向更完整的 distributed serving stack 收敛，重点在路由、KV locality、PD 和集群级调度智能
+- `vLLM Production Stack` 当前定位仍是 upstream 参考部署栈，而不是统一控制面
+- `SGLang` 同时覆盖 runtime 和 gateway；`RBG` 负责多角色 workload API
+- `LWS/DisaggregatedSet` 开始把多角色、多 LWS 的协调更新和版本感知服务编排做成上游 primitive
+- `AIBrix`、`Kthena`、`Dynamo` 都在朝完整平台演进，只是各自绑定的生态与优化重点不同
 
-## 1. 过去一年最大的变化
+## 1. 当前格局
 
-2025 年这个话题常被讲成“大家都在做 PD 分离”。到 2026 年，这个说法已经不够用了。当前的主线更准确地说是：
+当前推理编排方案普遍在处理同一组系统问题：
 
-- 不是只解决“怎么起 Pod”，而是解决 **role-aware orchestration**
-- 不是只做 prefill/decode，而是把 **routing、KV、autoscaling、topology、failure handling** 一起纳入系统设计
-- 不是只选一个 CRD，而是在选一套 **runtime + serving + control plane + scheduling** 的组合
+- **角色编排**：prefill、decode、router、gateway 等角色如何表达与协同
+- **流量入口**：请求如何按拓扑、缓存命中、版本状态和负载分布路由
+- **KV 与状态管理**：跨副本、跨角色、跨节点的数据局部性如何维持
+- **扩缩容**：是否按 role、按 workload、按 SLA、按平台策略独立扩缩
+- **升级与恢复**：多角色服务如何协调 rollout、回滚和故障恢复
 
-几个旧印象已经需要更新：
+从公开资料看，可以先做如下归类：
 
-- `AIBrix` 不再是 “KubeRay 用户的方案”。官方安装文档已经明确：`KubeRay` 是可选组件，不装也能用 `StormService` 跑单机和多节点推理。
-- `Dynamo` 也不适合再简单概括成 “Grove 模式或 LWS 模式”。它已经形成了 `DGDR/DGD + Operator + Planner + Grove` 的 Kubernetes 路线。
-- `KServe` 与 `llm-d` 也不宜再理解成互斥关系。`KServe 0.17` 文档已经明确写出 `LLMInferenceService` built on `llm-d`。
-- `SGLang` 不只是 runtime。最新文档里的 `Model Gateway` 已经覆盖路由、Kubernetes service discovery、PD topology、可靠性控制和 Inference Gateway Mode。
+- `KServe` 当前是统一平台入口
+- `llm-d` 当前是分布式 serving 主线之一
+- `vLLM Production Stack` 当前是较轻的 upstream 部署栈
+- `SGLang` 当前同时覆盖 runtime 与 gateway
+- `RBG`、`DisaggregatedSet` 当前更偏上游 workload API
+- `AIBrix`、`Kthena`、`Dynamo` 当前都在形成各自的平台路径
 
-## 2. 先按层来拆，而不是按名字比
+## 2. 分层视角
 
-| 层次 | 代表项目 | 更像什么 |
+| 层次 | 代表项目 | 主要职责 |
 | --- | --- | --- |
-| Runtime / 引擎 | `vLLM`、`SGLang` | 在单 Pod 或多 Pod 内执行推理 |
-| Serving Stack | `vLLM Production Stack`、`llm-d` | 把 runtime 扩展成可部署、可路由、可观测的集群级服务 |
+| Runtime / 引擎 | `vLLM`、`SGLang` | 在单 Pod 或一组 tightly-coupled Pod 内执行推理 |
+| Serving Stack | `vLLM Production Stack`、`llm-d` | 把 runtime 组织成可部署、可路由、可观测的集群级服务 |
 | Platform / Control Plane | `KServe`、`AIBrix`、`Kthena`、`Dynamo` | 用 CRD、router、autoscaler、policy 去统一管理推理生命周期 |
-| Workload Primitive | `RBG`、`LWS/DisaggregatedSet` | 为多角色、多节点、强协作 workload 提供更合适的 Kubernetes API |
+| Workload Primitive | `RBG`、`LWS/DisaggregatedSet` | 为多角色、多节点、强协作 AI workload 提供更合适的 Kubernetes API |
 
-这个分层视角会直接影响你的选型逻辑：
+这个分层直接决定了比较方式：
 
-- 如果你在找的是“统一入口和治理能力”，就应该优先比较 `KServe / AIBrix / Kthena / Dynamo`
-- 如果你在找的是“高性能分布式 serving 方案”，重点应放在 `llm-d / vLLM Production Stack / SGLang Gateway`
-- 如果你在找的是“多角色 workload API”，那就更该看 `RBG / LWS / DisaggregatedSet`
+- `KServe / AIBrix / Kthena / Dynamo` 更适合放在平台层对比
+- `llm-d / vLLM Production Stack / SGLang Gateway` 更适合放在 serving stack 层对比
+- `RBG / LWS / DisaggregatedSet` 更适合放在 workload primitive 层对比
 
-## 3. KServe：更像统一 AI 推理平台，而不是单一 runtime 包装器
+## 3. KServe
 
-截至 `2026-05-13`，KServe 官网已经把自己定位成 **Standardized Distributed Generative and Predictive AI Inference Platform**。它当前最重要的变化不是“能跑 LLM 了”，而是把 Generative 路线单独做成了 `LLMInferenceService`。
+截至 `2026-05-13`，KServe 官网把自己定位成 **Standardized Distributed Generative and Predictive AI Inference Platform**。当前 Generative AI 路线明确落到 `LLMInferenceService`。
 
-从官方 `0.17` 文档看，`LLMInferenceService` 的关键信号非常明确：
+从公开 `0.17` 文档可以看到几件事：
 
-- 它是面向 Generative AI 的独立 CRD，不再把 LLM 只塞进传统 `InferenceService`
-- 它直接建立在 `llm-d` 之上
-- 它在平台层暴露了多节点、PD 分离、Advanced Routing、DP+EP 等能力
-- 它同时保留了 KServe 一贯擅长的统一 API、生命周期管理、Gateway API 集成和企业运维治理
+- `LLMInferenceService` 是面向 Generative AI 的独立 CRD
+- 它明确建立在 `llm-d` 之上
+- 它在平台层暴露了多节点推理、PD 分离、Advanced Routing、DP+EP 等能力
+- 它仍保留 KServe 一贯的统一 API、生命周期管理、Gateway API 集成和平台治理方式
 
-这意味着，今天很多场景下你不该再问 “KServe or llm-d”，而更应该问：
+因此，当前更准确的理解不是“`KServe` 或 `llm-d`”，而是：
 
-`KServe` 是否是我想要的控制面，`llm-d` 是否是我愿意接受的底层 distributed serving stack？
+- `KServe` 负责平台入口与治理
+- `llm-d` 负责底层 distributed serving 能力
 
-如果你已经有：
+在标准 Kubernetes 平台、统一模型交付流程和 Gateway API 路线中，这是一组比较自然的组合。
 
-- `Knative/KServe` 经验
-- 标准 Kubernetes API 驱动的模型交付流程
-- 统一流量入口、配额、网关策略、团队边界
+## 4. llm-d
 
-那么 `KServe + llm-d` 往往是最自然的组合。
+`llm-d` 当前更接近 **Kubernetes-native distributed inference serving stack**，而不是通用平台，也不是单纯的 `vLLM` 部署模板。
 
-## 4. llm-d：高性能 distributed serving stack
-
-`llm-d` 的位置越来越清楚了。它不是通用平台，也不是单纯的 vLLM deployment 模板，而是一个 **Kubernetes-native distributed inference serving stack**。
-
-截至 `2026-05-12` 发布的 `v0.7.0`，官方 release 和文档显示它的核心能力已经比较完整：
+截至 `2026-05-12` 发布的 `v0.7.0`，公开材料显示它的主线已经比较完整：
 
 - Router / Scheduler 作为一等组件
 - KV cache aware routing
 - Prefill/Decode disaggregation
-- LeaderWorkerSet 作为多节点编排路径之一
-- variant autoscaler
+- `LeaderWorkerSet` 作为多节点编排路径之一
+- variant autoscaling
 - 与 Gateway API inference extension 的整合
-- 新增更完整的 `SGLang` well-lit path
+- 更清晰的 `SGLang` 支持路径
 
-它的价值主要在“集群级智能”，而不是“单 Pod 里把 kernel 跑得更快”：
+它的重点在于集群级智能，而不是单个 runtime Pod 的性能本身：
 
-- 请求是否命中前缀缓存
-- prefill 和 decode 是否落在最合适的资源池
-- router 是否能做更细粒度 endpoint 选择
+- 请求是否保留前缀缓存局部性
+- prefill 和 decode 是否落在合适的资源池
+- router 是否能做比通用负载均衡更细的 endpoint 选择
 - 多租户和大模型场景下的 tail latency 与 GPU 利用率如何控制
 
-如果你已经认定：
+## 5. vLLM Production Stack
 
-- 需要 cluster-wide cache aware routing
-- 需要 role-aware / PD-aware serving
-- 需要比 `vLLM + Service` 更强的集群级调度智能
+`vLLM Production Stack` 当前定位是 **upstream 参考部署栈**。官方 README 的定位是 **vLLM’s reference system for K8S-native cluster-wide deployment**。
 
-那么 `llm-d` 是目前最清晰的一条路线之一。
+截至 `2026-05-07`，最新 release 是 `vllm-stack-0.1.11`。当前公开形态主要包括：
 
-## 5. vLLM Production Stack：更轻的 upstream reference stack
-
-`vLLM Production Stack` 不应和 `llm-d`、`KServe`、`Dynamo` 放在同一层理解。它在官方 README 中的定位更朴素：**vLLM’s reference system for K8S-native cluster-wide deployment**。
-
-截至 `2026-05-07`，最新 release 是 `vllm-stack-0.1.11`。当前公开形态的重点是：
-
-- Helm 驱动的部署方式
+- Helm 部署
 - request router
 - Prometheus + Grafana observability
 - LMCache / KV cache offloading
-- 在不改应用代码的前提下，从单实例扩到分布式 vLLM
+- 从单实例扩展到 cluster-wide vLLM 的参考路径
 
-这条路线的优点很明确：
+它的特点比较清楚：
 
-- 对已经标准化 `vLLM` 的团队最友好
-- 栈更薄，更像 reference stack 而不是完整平台
-- 能较快落地基础的路由、观测和 cache offloading
+- 更接近 upstream `vLLM`
+- 栈更薄
+- 路由、观测与 cache offloading 已经具备基础能力
 
-它的边界也同样明确：
+同时，它当前并不试图承担统一 control plane 的角色，也不提供 `KServe / AIBrix / Kthena / Dynamo` 那种完整平台治理面。
 
-- 它不是统一 control plane
-- 它不试图提供 `KServe / AIBrix / Kthena / Dynamo` 那样的完整平台治理能力
-- 它更适合作为“先用起来”的起点，而不是“一次性解决所有多角色编排问题”的终点
+## 6. SGLang、RBG 与 LWS/DisaggregatedSet
 
-如果你只想回答“如何更稳妥地在 Kubernetes 上部署一套 upstream vLLM 集群”，那它是很合理的第一站。
+这一组更适合放在一起理解，因为它们分别覆盖 runtime、gateway 与 workload primitive。
 
-## 6. SGLang 与 RBG：runtime/gateway 和 workload API 要分开看
+### 6.1 SGLang
 
-这两者最容易被混成一个东西，但实际上不是同一层。
+SGLang 当前同时覆盖 runtime 与 gateway。
 
-### 6.1 SGLang：高性能 runtime，外加越来越完整的 Model Gateway
+最新公开文档与 release 说明，当前重点包括：
 
-SGLang 官方文档当前已经同时强调两件事：
+- 高性能 serving framework
+- PD disaggregation、HiCache、多种并行方式和广泛硬件支持
+- `SGLang Model Gateway`，覆盖 HTTP/gRPC/OpenAI-compatible 路由、Kubernetes service discovery、PD topology、观测与可靠性控制
+- `Unified Inference Gateway Mode`
 
-- 它本身是高性能 serving framework，支持 PD disaggregation、HiCache、多种并行方式、广泛硬件平台
-- 它现在还有 `SGLang Model Gateway`，提供 HTTP/gRPC/OpenAI-compatible 路由、Kubernetes service discovery、PD topology、可靠性控制、观测与 Inference Gateway Mode
+因此，SGLang 在这里同时覆盖两层：
 
-截至 `2026-05-05` 的 `v0.5.11` release，SGLang 又强化了一个重要方向：**统一 Inference Gateway Mode**。这意味着它不仅是一个 runtime，也越来越像“自带 gateway 的 serving stack”。
+- runtime 层能力较强
+- 同时在向 serving stack 方向延展
 
-所以，如果你的团队已经明确站在 `SGLang` 路线上，第一选择往往不是“换个平台”，而是：
+### 6.2 RBG
 
-- 先用 `SGLang runtime`
-- 再用 `SGLang Model Gateway` 扩展成可运维的集群入口
+`RBG` 的重点不在 gateway，而在 `RoleBasedGroup` 这种多角色 workload API。
 
-### 6.2 RBG：多角色 workload primitive
-
-`RBG` 的价值不在于当 gateway，而在于提供 `RoleBasedGroup` 这种更适合分布式推理服务的 Kubernetes workload API。
-
-它 README 里公开强调的点包括：
+其 README 公开强调的能力包括：
 
 - role startup-order dependencies
-- auto service discovery
-- group/role 级 elastic scaling
+- automated service discovery
+- group-level 与 role-level elastic scaling
 - atomic rollout
 - topology-aware placement
 - atomic failure recovery
-- 可定制 workload backend，包括 `StatefulSet`、`Deployment`、`LeaderWorkerSet`
+- 多种 role backend，包括 `StatefulSet`、`Deployment`、`LeaderWorkerSet`
 
-所以更准确的定位是：
+这意味着 `RBG` 主要解决的是：如何把多角色推理服务表达成 Kubernetes workload primitive。
 
-- `SGLang` 解决 runtime 和 gateway
-- `RBG` 解决多角色 workload 如何在 Kubernetes 上被表达和编排
+### 6.3 LWS / DisaggregatedSet
 
-如果你是 `SGLang` 用户，又觉得 `Deployment/StatefulSet` 对多角色服务表达不够好，`RBG` 就值得重点看。
+`DisaggregatedSet` 是 `LeaderWorkerSet` 项目提出的新 CRD，目标是把原本需要人工协调的多个 `LeaderWorkerSet` 收敛成一个统一对象。
 
-## 7. AIBrix：模块化的 GenAI 基础设施平台
+从 KEP-766 当前公开草案看，它要解决的核心问题是：
 
-`AIBrix` 当前更像“模块化平台”，而不是单一 CRD。
+- 多个 LWS 的升级如何协调
+- 多角色服务的版本一致性如何保证
+- revision-aware Service 如何自动生成
+- 多角色 rollout 如何避免孤儿工作负载和配置漂移
 
-截至 `2026-03-03` 的 `v0.6.0` 与最新文档，几个信号已经很明确：
+当前公开设计里，几个点比较关键：
 
-- 官方安装文档明确支持 vanilla Kubernetes
+- **`spec.roles`**：每个 role 内嵌完整的 `LeaderWorkerSetTemplateSpec`
+- **N 维协调式滚动更新**：多个角色按统一 revision 与步骤推进，而不是各自独立 rollout
+- **每 revision 的 headless Service**：例如 `{name}-{revision}-{role}-prv`，为 `llm-d` 这类上层路由器提供按 revision 比例路由的基础
+- **当前边界**：暂不覆盖 HPA/VPA、多集群和非 LWS 后端
+
+如果把 `RBG` 与 `DisaggregatedSet` 放在一起看，差别也比较清楚：
+
+- `RBG` 更通用，role backend 可以不是 LWS
+- `DisaggregatedSet` 更明确地站在 LWS 生态上，重点是多 LWS 的协调升级与服务编排
+
+## 7. AIBrix
+
+`AIBrix` 当前呈现为模块化平台设计，而不是单一 CRD。
+
+截至 `2026-03-03` 的 `v0.6.0` 与最新文档，公开信号包括：
+
+- vanilla Kubernetes 是一条明确路径
 - `Envoy Gateway` 是前置依赖
-- `KubeRay` 变成可选组件
+- `KubeRay` 已经变成可选组件
 - `StormService` 是其多节点编排主线之一
-- `Router`、`KV cache`、`PodAutoscaler`、`LoRA/Adapter` 等能力都在平台内独立演进
+- router、KV cache、pod autoscaler、LoRA/adapter 等能力都在平台内独立演进
 
-`StormService` 的价值在于，它不是单纯的 prefill/decode 模板，而是明确设计成三层结构：
+`StormService` 的关键点在于它不是单纯的 PD 模板，而是三层结构：
 
 - `StormService`
 - `RoleSet`
 - `Pods`
 
-并且它同时支持：
+当前公开设计还包括：
 
 - replica mode
 - pooled mode
 - top-level rolling / inplace update
 - RoleSet 级 parallel / sequential / interleaved update
+- pooled mode 下的 role-level autoscaling
 
-更重要的是，AIBrix 当前文档已经明确支持 pooled mode 下的 **role-level autoscaling**。这一点和很多只会说“支持 PD”的项目相比，工程含义更大，因为它真正触及了不同 role 负载形状不同这一现实。
+## 8. Kthena
 
-如果你的偏好是：
+Kthena 当前已经明确把自己定位成 **Kubernetes-native AI serving platform**。
 
-- vanilla Kubernetes
-- 组件化平台
-- Router、Autoscaler、KV、LoRA 都希望是平台一部分
-- 不想深度绑定 `Volcano` 或 NVIDIA 自家整栈
-
-那么 `AIBrix` 是很强的候选。
-
-## 8. Kthena：Volcano 原生的完整推理控制面
-
-Kthena 到现在已经不是一个“Volcano 旁边的实验项目”了。`v0.4.0` 官方文档把它定义得很直接：**Kubernetes-native AI serving platform**。
-
-它当前的特点，不是“也支持 PD”，而是把下面这些能力组织到了一套面向服务的平台抽象里：
+它的主线不是“支持某一种 workload”，而是围绕一组平台抽象组织能力：
 
 - `ModelBooster`
 - `ModelRoute`
@@ -255,29 +250,22 @@ Kthena 到现在已经不是一个“Volcano 旁边的实验项目”了。`v0.4
 - `AutoScalingPolicy`
 - `AutoScalingPolicyBinding`
 
-从当前文档和官方博客看，Kthena 的强项在于：
+从当前文档与官方博客看，Kthena 的几个特点比较稳定：
 
-- 与 `Volcano` 调度生态天然亲和
-- 面向多后端引擎，包括 `vLLM`、`SGLang`、`Triton`、`TorchServe`
+- 与 `Volcano` 调度生态亲和
+- 支持多后端，包括 `vLLM`、`SGLang`、`Triton`、`TorchServe`
 - request-level intelligent routing
 - token-based rate limit、canary、failover
 - role-aware PD routing
 - 多指标、成本驱动 autoscaling
 
-另外，Kthena 的一个重要变化是它对 LWS 的态度。公开 proposal 与后续 PR 说明，它并不是排斥 `LeaderWorkerSet`，而是在探索 **LWS API compatibility**，把 LWS 视作一个可兼容的 northbound 接口，而不是唯一底层 primitive。
+同时，公开 proposal 与后续 PR 也显示，Kthena 正在探索 **LWS API compatibility**。因此，LWS 在其中更接近兼容的 northbound 接口，而不是唯一底层 primitive。
 
-这意味着如果你已经站在：
+## 9. Dynamo
 
-- `Volcano`
-- gang scheduling
-- topology-aware placement
-- heterogenous accelerator orchestration
+`Dynamo` 当前定位是 **性能系统优先的推理平台**。
 
-这一侧，那么 Kthena 往往比其他方案更“原生”。
-
-## 9. Dynamo：性能系统优先的推理平台
-
-`Dynamo` 现在最不应该被简化成“一个编排器”。从官方文档看，它已经明显是一整套平台：
+从官方文档看，它已经明显是一整套平台：
 
 - `DynamoGraphDeploymentRequest (DGDR)`：推荐的、简化的 SLA 驱动入口
 - `DynamoGraphDeployment (DGD)`：更直接的底层配置入口
@@ -287,151 +275,95 @@ Kthena 到现在已经不是一个“Volcano 旁边的实验项目”了。`v0.4
 - `KVBM`
 - 与 `Grove` 的多节点编排整合
 
-官方 Kubernetes deployment guide 和 Grove 文档显示，Dynamo 当前的思路非常清楚：
+Kubernetes deployment guide 与 Grove 文档显示，当前路线非常清楚：
 
 - 平台层由 `DGDR/DGD + Operator` 承担
 - 多节点、多角色编排主要交给 `Grove`
 - `Planner` 负责围绕 SLA 生成和调整部署形态
 
-`Grove` 这条线尤其值得注意。它公开把自己定义成：
+`Grove` 自己公开强调的点也很直接：
 
-- 专门为现代 AI workload，特别是 disaggregated inference 设计的 Kubernetes API
-- 能在单个资源中表达 prefill、decode、routing 等多个 component
+- 面向现代 AI workload，尤其是 disaggregated inference
+- 能在单个资源里表达 prefill、decode、routing 等多个 component
 - 支持 multi-level horizontal autoscaling、startup dependencies、topology-aware scheduling
 
-所以今天更准确的说法不是 “Dynamo 有 Grove 模式和 LWS 模式”，而是：
+## 10. 对比
 
-`Dynamo` 已经把性能系统、平台入口和 Kubernetes 编排主线组织起来了，而 `Grove` 是其中面向多角色、多节点编排的核心一环。
-
-如果你主要是：
-
-- `NVIDIA` 集群
-- 大模型、多节点、强 SLA 驱动
-- 更在意 profiler / planner / backend / KV 路径的一体化
-
-那么 `Dynamo` 的吸引力仍然最大。
-
-## 10. 一个更有意义的对比表
-
-| 方案 | 本质定位 | `role / PD` | 路由与网关 | 扩缩容 | 生态重心 |
+| 方案 | 定位 | `role / PD` | 路由与网关 | 扩缩容 | 生态重心 |
 | --- | --- | --- | --- | --- | --- |
-| `KServe` | 统一 AI inference 平台 | 强，但更多通过 `LLMInferenceService` 暴露 | 强，Gateway API 与 AI Gateway 明确成型 | 强 | 标准 K8s 平台、KServe 用户 |
+| `KServe` | 统一 AI inference 平台 | 强，通过 `LLMInferenceService` 暴露 | 强 | 强 | 标准 Kubernetes 平台 |
 | `llm-d` | distributed serving stack | 很强 | 很强 | 强 | 高性能分布式 LLM serving |
-| `vLLM Production Stack` | upstream reference stack | 有，但不是它当前最突出的卖点 | 中到强 | 中 | 纯 `vLLM` 用户 |
-| `SGLang` | runtime + gateway | 很强 | 很强 | 中到强 | `SGLang` runtime 用户 |
-| `RBG` | multirole workload API | 核心能力 | 以 service discovery 为主 | 强 | 需要通用多角色 primitive 的团队 |
-| `AIBrix` | 模块化 GenAI infra 平台 | 很强，`StormService/RoleSet` 已较成熟 | 强 | 强，role-level autoscaling 已落地 | vanilla Kubernetes + 平台组件组合 |
-| `Kthena` | Volcano-native AI serving platform | 很强，`ModelServing/ServingGroup/Role` | 很强 | 很强 | Volcano / 调度与拓扑优先 |
-| `Dynamo` | performance-first AI infra platform | 很强，`DGDR/DGD + Grove` | 很强 | 很强，Planner 能力突出 | NVIDIA / 多节点 / SLA 驱动 |
+| `vLLM Production Stack` | upstream reference stack | 有，但不是当前最突出的卖点 | 中到强 | 中 | 纯 `vLLM` 生态 |
+| `SGLang` | runtime + gateway | 很强 | 很强 | 中到强 | `SGLang` runtime 与 gateway |
+| `RBG` | multirole workload API | 核心能力 | 以 service discovery 为主 | 强 | 通用多角色 primitive |
+| `LWS / DisaggregatedSet` | LWS 上层多角色 primitive | 很强 | 以 revision-aware Service orchestration 为主 | 当前扩缩边界较保守 | LWS 生态 |
+| `AIBrix` | 模块化 GenAI infra 平台 | 很强，`StormService/RoleSet` 已较成熟 | 强 | 强，role-level autoscaling 已公开落地 | vanilla Kubernetes + 平台组件 |
+| `Kthena` | Volcano-native AI serving platform | 很强，`ModelServing/ServingGroup/Role` | 很强 | 很强 | Volcano / 调度与拓扑 |
+| `Dynamo` | performance-first AI infra platform | 很强，`DGDR/DGD + Grove` | 很强 | 很强，Planner 能力突出 | NVIDIA / 多节点 / SLA |
 
-## 11. 怎么选：按你已有基础设施来
+## 11. 场景观察
 
-下面给一个简化版决策指南。真实场景里还要考虑模型形态、GPU 代际、网络拓扑、成本模型、平台团队能力和多租户边界。
+下面是一个简化版的场景观察，重点放在生态与基础设施关系，而不是抽象地讨论“谁更好”。
 
-### 如果你已经是 Volcano 用户
+### Volcano 环境
 
-优先看 `Kthena`。
+`Kthena` 与 `Volcano` 的调度和平台抽象靠得最近，gang scheduling、topology-aware placement 和推理角色编排可以放在同一条链路中理解。
 
-原因不是“它也支持推理”，而是它的调度与平台抽象天然站在同一个生态里。你会更容易把：
+### KServe 环境
 
-- gang scheduling
-- topology-aware scheduling
-- 推理 role 编排
-- route/scale/policy
+`KServe + llm-d` 是当前公开材料里较常见的组合：前者承担平台入口与治理，后者承担底层 distributed serving 能力。
 
-放进一条统一链路。
+### vLLM 环境
 
-### 如果你已经是 KServe 用户
+`vLLM Production Stack` 适合更轻的 upstream 部署路径；`llm-d` 更适合需要 cluster-wide routing、KV locality 和 PD orchestration 的场景。
 
-优先看 `KServe + llm-d`，而不是把两者当成二选一。
+### NVIDIA 环境
 
-`KServe` 更像 control plane，`llm-d` 更像 distributed intelligence / serving stack。对于已经围绕 `InferenceService`、Gateway API、平台治理构建流程的团队，这通常是最自然的升级路径。
+`Dynamo` 与 `Grove` 的组合更强调 profiler、planner、backend、KV 和多节点编排的一体化路径。
 
-### 如果你主要是 vLLM 用户
+### vanilla Kubernetes 环境
 
-先问自己要的是“最轻方案”还是“最强 serving stack”：
+`AIBrix` 当前在平台组件化方面最明确，`Envoy Gateway`、`StormService`、`Router`、`PodAutoscaler`、`KV Cache` 能组成较完整的控制面。
 
-- 想先快速得到一套 upstream 参考部署：`vLLM Production Stack`
-- 已经明确需要 cache-aware routing、PD、cluster-level intelligence：`llm-d`
+### SGLang 环境
 
-### 如果你主要是 NVIDIA 集群
+`SGLang` 与 `RBG` 更像上下游关系：前者负责 runtime 与 gateway，后者负责多角色 workload API。
 
-优先看 `Dynamo`，尤其是：
+### 上游 primitive 路线
 
-- 多节点大模型
-- 强 SLA 驱动
-- 希望用 profiler / planner 来辅助配置选择
-- 希望 route、KV、backend、orchestration 一起优化
+`RBG` 与 `LWS/DisaggregatedSet` 都值得关注，但侧重点不同：
 
-### 如果你是 vanilla Kubernetes 团队
+- `RBG` 更通用
+- `DisaggregatedSet` 更聚焦在 LWS 生态内的多角色协调更新与服务编排
 
-优先看 `AIBrix`。
+## 12. PD 分离的适用边界
 
-它目前在“平台组件化”和“不过度绑定某个单一调度器”之间的平衡比较清晰。你可以更自然地组合：
-
-- `Envoy Gateway`
-- `StormService`
-- `Router`
-- `PodAutoscaler`
-- `KV Cache`
-
-### 如果你是 SGLang 用户
-
-优先顺序通常是：
-
-1. `SGLang runtime`
-2. `SGLang Model Gateway`
-3. 如果还需要更强的 Kubernetes 多角色 workload API，再补 `RBG`
-
-换句话说，`SGLang` 与 `RBG` 更像上下配合，而不是互相替代。
-
-### 如果你想要更“上游 primitive”的路线
-
-可以重点关注：
-
-- `RBG`
-- `LWS + DisaggregatedSet`
-
-这一层的价值在于 workload API，而不是完整平台。
-
-## 12. PD 分离仍然不是默认答案
-
-这一点到今天依然成立。
-
-虽然这几个方向几乎都在强化 `prefill/decode` 分离，但“支持 PD”不等于“PD 一定值得”。
+PD 分离当前已经不是单点技巧，而是一整套系统设计的一部分。但“支持 PD”不等于“PD 在所有场景都值得”。
 
 更适合引入 PD 的情况通常包括：
 
 - 长 prompt、短输出
 - 高并发，且请求形状差异大
 - prefill 与 decode 对硬件偏好明显不同
-- 你确实要单独优化 `TTFT` 与 `TPOT`
+- `TTFT` 与 `TPOT` 需要分开优化
 
-更应该谨慎的情况包括：
+更需要谨慎评估的情况通常包括：
 
 - 短上下文或中小模型
 - 低并发
 - 同构硬件
 - KV 传输和跨 role 协调成本可能吞掉收益
-- 团队目前还没有足够观测与运维能力
-
-今天的进步主要是：平台终于开始把 PD 从“实验室技巧”做成“可运维能力”。但它仍然不是银弹。
+- 平台观测、路由与故障处理能力尚未成型
 
 ## 结语
 
-截至 `2026-05-13`，这个领域的主线已经不是“谁支持 PD”，而是“谁能把 role-aware orchestration、routing、autoscaling、topology 和 failure handling 组织成一套可落地的系统”。
+截至 `2026-05-13`，更适合的比较方式是先看各项目在推理系统里负责哪一层。
 
-所以真正要回答的，不只是 “AIBrix or Kthena or Dynamo”，而是：
+如果按这一视角归纳：
 
-- 你是在选 **runtime**、**serving stack**、**平台**，还是 **workload API**
-- 你更在意 **生态兼容**，还是 **性能系统能力**
-- 你是想贴近 **上游通用抽象**，还是接受某个生态更强的整栈绑定
+- `vLLM`、`SGLang` 主要是 runtime
+- `vLLM Production Stack`、`llm-d` 主要是 serving stack
+- `KServe`、`AIBrix`、`Kthena`、`Dynamo` 主要是平台
+- `RBG`、`LWS/DisaggregatedSet` 主要是 workload primitive
 
-如果只保留一句话：
-
-- 想要模块化平台：`AIBrix`
-- 想要 Volcano 原生推理控制面：`Kthena`
-- 想要性能系统优先、尤其是 NVIDIA 路线：`Dynamo`
-- 想要 K8s 上高性能 distributed serving：`llm-d`
-- 想先上最轻的 upstream vLLM 参考栈：`vLLM Production Stack`
-- 已经是 SGLang 体系：`SGLang Gateway + RBG`
+这样再看各项目的角色、边界和组合关系，通常会比把所有名字放在同一层横向比较更清楚。

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-05-12
+last_updated: 2026-05-13
 tags: blog, kubernetes, ai-infrastructure
 ---
 
@@ -11,6 +11,24 @@ Older posts have been archived to [docs/archive-blog](../archive-blog/README.md)
 
 This directory contains blog posts and articles about AI infrastructure,
 Kubernetes scheduling, and related topics.
+
+## 2026-05-13: 推理编排方案如何选择？AIBrix、Kthena、Dynamo、llm-d、KServe、vLLM Production Stack 与 SGLang/RBG
+
+- [推理编排方案如何选择？AIBrix、Kthena、Dynamo、llm-d、KServe、vLLM Production Stack 与 SGLang/RBG (Chinese)](./2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks_zh.md)
+- [How to choose an inference orchestration stack: AIBrix, Kthena, Dynamo, llm-d, KServe, vLLM Production Stack, and SGLang/RBG](./2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks.md)
+
+A bilingual update of the earlier inference orchestration theme, reframed
+around stack layers rather than project names:
+
+- **Do not compare unlike layers**: separates runtime, serving stack, control
+  plane, and workload primitive before comparing projects.
+- **Latest public progress**: updates `KServe + llm-d`, `AIBrix`, `Kthena`,
+  `Dynamo/Grove`, `vLLM Production Stack`, and `SGLang/RBG` to reflect their
+  current public positioning as of 2026-05-13.
+- **Infrastructure-first decision guide**: gives a practical selection path for
+  Volcano, KServe, vLLM, NVIDIA, vanilla Kubernetes, and SGLang users.
+- **PD is still conditional**: keeps the warning that prefill/decode
+  disaggregation is a systems tradeoff, not an automatic win.
 
 ## 2026-05-11: NVIDIA 推理编排主线拆解：Dynamo、Grove、KAI Scheduler 与 GPU DRA Driver
 


### PR DESCRIPTION
## What changed

This PR adds a bilingual blog update for the inference orchestration topic:

- adds a new Chinese post under `docs/blog/2026-05-13/`
- adds a new English post under `docs/blog/2026-05-13/`
- updates `docs/blog/README.md` with the new blog index entry

## Why

The older inference orchestration write-up was based on an earlier snapshot of the ecosystem. This update reframes the topic around stack layers and refreshes the comparison using the latest public progress across:

- KServe
- llm-d
- vLLM Production Stack
- AIBrix
- Kthena
- Dynamo
- SGLang / RBG

## Impact

- provides a current bilingual decision guide for readers comparing inference orchestration stacks
- makes the differences between runtime, serving stack, platform, and workload primitive clearer
- preserves the earlier caution that PD disaggregation is conditional rather than an automatic win

## Validation

- `git diff --check --cached`
- manually reviewed the new bilingual blog content and blog index entry

