### PR TITLE
docs: refine GPU sharing cross-links

### DIFF
--- a/docs/inference/README.md
+++ b/docs/inference/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-05-26
+last_updated: 2026-07-10
 tags: inference, llm, vllm, serving, optimization
 canonical_path: docs/inference/README.md
 ---
@@ -295,6 +295,7 @@ Run multiple workloads on a single GPU to increase utilization:
 | **Time-slicing** | CUDA time-multiplexing between pods | Small models, dev/test |
 | **MIG (Multi-Instance GPU)** | Hardware GPU partitioning (A100/H100) | Isolated, predictable workloads |
 | **MPS (Multi-Process Service)** | CUDA context sharing with memory isolation | Batch inference, high throughput |
+| **HAMi** | Software GPU memory/core quotas and scheduling | Flexible fractions, heterogeneous accelerators |
 | **vGPU** | Virtualized GPU with memory limits | Enterprise multi-tenancy |
 
 **MIG configuration via NVIDIA GPU Operator:**
@@ -305,7 +306,9 @@ Run multiple workloads on a single GPU to increase utilization:
 kubectl label node <node> nvidia.com/mig.config=all-1g.10gb
 ```
 
-See [NVIDIA GPU Operator](../kubernetes/nvidia-gpu-operator.md) for MIG setup.
+See [NVIDIA GPU Operator](../kubernetes/nvidia-gpu-operator.md) for MIG setup,
+and [HAMi / MIG / GPU Sharing](../kubernetes/hami-gpu-sharing.md) for
+platform-level tradeoffs.
 
 ### Spot / Preemptible Instances
 

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -106,14 +106,14 @@ workload isolation.
    GPU workloads
 2. Review [NVIDIA GPU Operator](./nvidia-gpu-operator.md) for GPU setup and
    monitoring
-3. Use [NVIDIA AICR](./nvidia-aicr.md) for validated, reproducible cluster
+3. Use [HAMi / MIG / GPU Sharing](./hami-gpu-sharing.md) when choosing between
+   full GPUs, MIG, time-slicing, MPS, vGPU, HAMi, and DRA-backed devices
+4. Use [NVIDIA AICR](./nvidia-aicr.md) for validated, reproducible cluster
    recipes on EKS, GKE, or self-managed clusters
-4. Study [GPU Fault Detection](./gpu-fault-detection.md) for production
+5. Study [GPU Fault Detection](./gpu-fault-detection.md) for production
    reliability and automated recovery
-5. Study [Isolation Guide](./isolation.md) for checkpoint/restore
-6. Understand [DRA](./dra.md) for complex device requirements
-7. Read [HAMi / GPU Sharing](./hami-gpu-sharing.md) for fractional GPU and MIG
-   selection
+6. Study [Isolation Guide](./isolation.md) for checkpoint/restore
+7. Understand [DRA](./dra.md) for complex device requirements
 
 ## Related Topics
 

--- a/docs/kubernetes/dra.md
+++ b/docs/kubernetes/dra.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-05-09
+last_updated: 2026-07-10
 tags: kubernetes, dra, resource-allocation, device-management, topology
 canonical_path: docs/kubernetes/dra.md
 ---
@@ -11,6 +11,9 @@ canonical_path: docs/kubernetes/dra.md
 [DRA](https://github.com/kubernetes/dynamic-resource-allocation/) is Dynamic
 Resource Allocation for Kubernetes, enabling flexible device allocation with
 structured parameters and topology awareness.
+
+For GPU-specific sharing choices across HAMi, MIG, MPS, vGPU, and DRA, see
+[HAMi / MIG / GPU Sharing](./hami-gpu-sharing.md).
 
 ## Overview
 
@@ -70,7 +73,8 @@ Requirements:
 [Scheduling Optimization Guide](./scheduling-optimization.md#26-topology-aware-scheduling)
 for DRA usage in production scenarios, and
 [HAMi / MIG / GPU Sharing](./hami-gpu-sharing.md) for how DRA partitionable
-devices relate to MIG, HAMi, and fractional GPU pools.
+devices relate to MIG, HAMi, fractional GPU pools, and GPU isolation
+mechanisms.
 
 ## KEPs and Roadmap
 

--- a/docs/kubernetes/isolation.md
+++ b/docs/kubernetes/isolation.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-07-09
+last_updated: 2026-07-10
 tags: kubernetes, isolation, security, multi-tenancy
 canonical_path: docs/kubernetes/isolation.md
 ---
@@ -336,6 +336,11 @@ Agent sandboxes provide secure execution environments for AI agents that can
 execute arbitrary code, access tools, and interact with external systems.
 Unlike traditional workload isolation, agent sandboxes must handle untrusted
 LLM-generated code while supporting fast startup and high concurrency.
+
+When agent workloads also need GPUs, combine this isolation model with the
+GPU sharing decision guide in [HAMi / MIG / GPU Sharing](./hami-gpu-sharing.md).
+GPU sharing controls capacity; it does not replace a runtime boundary for
+untrusted code.
 
 ### Core Requirements
 
@@ -960,6 +965,7 @@ Match isolation strength to threat model:
 | Trusted Internal Training | Standard | cgroups + SecurityContext |
 | Multi-Tenant Inference | Enhanced | + User namespaces |
 | External User Code | Strong | Kata Containers + Agent Sandbox |
+| GPU-Accelerated Agent Code | Strong | Kata/KubeVirt boundary + full GPU, MIG, or vGPU |
 | Sensitive Data Processing | Maximum | Kata + Encryption + Net Policy |
 
 ### Performance vs Security Trade-offs

--- a/docs/kubernetes/nvidia-gpu-operator.md
+++ b/docs/kubernetes/nvidia-gpu-operator.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2025-10-31
+last_updated: 2026-07-10
 tags: kubernetes, nvidia, gpu, dra, device-plugin, gpu-operator
 canonical_path: docs/kubernetes/nvidia-gpu-operator.md
 ---
@@ -21,6 +21,9 @@ NVIDIA software components required to run GPU-accelerated workloads. It
 eliminates the need to manually install and configure GPU drivers and CUDA
 libraries on each node.
 
+For a platform-level decision guide across full GPUs, MIG, time-slicing, MPS,
+vGPU, HAMi, and DRA, see [HAMi / MIG / GPU Sharing](./hami-gpu-sharing.md).
+
 ### Key Features
 
 - Automated GPU driver installation and upgrades
@@ -28,7 +31,7 @@ libraries on each node.
 - Device plugin deployment for GPU resource management
 - GPU monitoring and telemetry (DCGM Exporter)
 - Support for multiple GPU architectures and configurations
-- Dynamic Resource Allocation (DRA) integration (upcoming)
+- MIG, time-slicing, vGPU, and Dynamic Resource Allocation (DRA) integration
 
 ## Core Components
 
@@ -325,6 +328,8 @@ allowing operators to choose based on their requirements.
 
 - **[Dynamic Resource Allocation (DRA)](./dra.md)**: Understanding DRA
   concepts and architecture
+- **[HAMi / MIG / GPU Sharing](./hami-gpu-sharing.md)**: Choosing between
+  GPU partitioning, time sharing, virtual GPUs, software quotas, and DRA
 - **[Scheduling Optimization](./scheduling-optimization.md)**: GPU scheduling
   strategies and best practices
 - **[Node Resource Interface (NRI)](./nri.md)**: Fine-grained container

--- a/docs/kubernetes/scheduling-optimization.md
+++ b/docs/kubernetes/scheduling-optimization.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-03-24
+last_updated: 2026-07-10
 tags: kubernetes, scheduling, optimization, large-scale
 canonical_path: docs/kubernetes/scheduling-optimization.md
 ---
@@ -623,13 +623,16 @@ are becoming tightly coupled platform concerns. For platform teams, this means
 GPU should be treated as a schedulable resource layer, not only a node-level
 device flag.
 
+For the full platform decision matrix across HAMi, MIG, time-slicing, MPS,
+vGPU, and DRA, see [HAMi / MIG / GPU Sharing](./hami-gpu-sharing.md).
+
 | Option | Best For | Main Trade-offs |
 | --- | --- | --- |
 | MIG (hardware partitioning) | Strong isolation and predictable slices | Static partitioning, lower elasticity for mixed workloads |
 | Time-slicing / MPS | Higher utilization for bursty inference | Weaker isolation and noisy-neighbor risk |
-| HAMI | Multi-tenant sharing with scheduler-visible GPU fractions | Extra control-plane complexity and compatibility validation |
+| HAMi | Multi-tenant sharing with scheduler-visible GPU fractions | Extra control-plane complexity and compatibility validation |
 
-**When HAMI is worth evaluating:**
+**When HAMi is worth evaluating:**
 
 - You need multi-tenant GPU sharing beyond basic MIG partitioning
 - You need scheduler-visible sharing ratios/quotas for mixed workloads
@@ -637,7 +640,7 @@ device flag.
 
 **Guardrails (keep adoption pragmatic):**
 
-- Treat HAMI as an optional implementation, not a mandatory architecture layer
+- Treat HAMi as an optional implementation, not a mandatory architecture layer
 - Validate compatibility matrix in staging first: Kubernetes version, driver,
   container runtime, CUDA stack, and observability pipeline
 - Benchmark against your baseline (`MIG + native scheduler` or
@@ -907,8 +910,8 @@ SLA-based scheduling complements other optimization strategies:
   Dynamic Resource Allocation for Kubernetes
 - <a href="https://github.com/containerd/nri">`NRI`</a>: Node Resource
   Interface for containerd
-- <a href="https://github.com/Project-HAMi/HAMi">`HAMI`</a>: CNCF Sandbox,
-  GPU sharing
+- <a href="https://github.com/Project-HAMi/HAMi">`HAMi`</a>: GPU sharing and
+  accelerator virtualization
 
 **Monitoring:**
 


### PR DESCRIPTION
## Summary

Follow-up to #372 and #379. The main HAMi / MIG / GPU sharing guide is already merged; this PR tightens the surrounding cross-links and terminology so related docs point readers to the new decision guide consistently.

## Changes

- Add HAMi / MIG / GPU sharing references from inference, isolation, DRA, GPU Operator, and scheduling docs.
- Clarify that DRA allocation semantics are separate from GPU isolation mechanisms.
- Add GPU-accelerated Agent code guidance to the workload isolation matrix.
- Normalize `HAMi` spelling in the scheduling guide.

## Validation

- `git diff --cached --check`

`markdownlint` and `markdown-link-check` were not available in the local environment.