### PR TITLE
docs: update upstream project releases

### DIFF
--- a/docs/blog/2026-04-13/2026-04-13-ai-training-job-management-jobset-kueue-ray-gang_zh.md
+++ b/docs/blog/2026-04-13/2026-04-13-ai-training-job-management-jobset-kueue-ray-gang_zh.md
@@ -2,12 +2,12 @@
 status: Active
 maintainer: pacoxu
 date: 2026-04-13
-last_updated: 2026-07-11
+last_updated: 2026-07-24
 tags: kubernetes, training, jobset, kueue, kuberay, gang-scheduling, workload-aware-scheduling
 canonical_path: docs/blog/2026-04-13/2026-04-13-ai-training-job-management-jobset-kueue-ray-gang_zh.md
 source_urls:
   - https://api.github.com/repos/pacoxu/AI-Infra/issues/300
-  - https://api.github.com/repos/kubernetes-sigs/kueue/releases/tags/v0.18.3
+  - https://api.github.com/repos/kubernetes-sigs/kueue/releases/tags/v0.19.0
   - https://api.github.com/repos/kubernetes-sigs/jobset/releases/tags/v0.12.0
   - https://api.github.com/repos/ray-project/kuberay/releases/tags/v1.6.2
   - https://raw.githubusercontent.com/kubernetes/enhancements/master/keps/sig-scheduling/4671-gang-scheduling/kep.yaml
@@ -31,7 +31,7 @@ source_urls:
 它们不是四个互斥选择，而是一组可以组合的控制面能力。
 
 本文原计划发布日是 **2026-04-13**。版本、发布日期和特性阶段按
-**2026-07-11** 的公开信息重新核对。
+**2026-07-24** 的公开信息重新核对。
 
 ## 先说结论
 
@@ -104,6 +104,14 @@ checkpoint 和失败恢复策略。
 Kueue 负责 RayCluster/RayJob 进入集群前的资源准入。这样既保留 Ray 的编程模型，
 也避免 Ray 集群绕过平台配额。
 
+升级到 Kueue `v0.19.0` 时，Ray 集成需要重新核算 head PodSet 配额：
+启用 autoscaling 的 RayCluster 会额外计入 autoscaler sidecar，使用
+`submissionMode: SidecarMode` 的 RayJob 会计入 submitter sidecar。
+`WaitForPodsReady` 也已默认启用；未显式配置的集群会采用 30 分钟 timeout 与
+30 分钟 recovery timeout。自研 job framework integration 还需要为
+`RestorePodSetsInfo` 传入 Kubernetes context，并把 API 中对 `GroupVersion` 的引用迁移到
+`SchemeGroupVersion`。
+
 对正在跟进 upstream Kubernetes 的团队，可以把 KEP-4671 的 gang scheduling 视为未来
 原生收敛方向。它引入 workload-level API 思路，包括 `Workload` 与 `PodGroup` 这样的抽象。
 但需要注意，KEP 明确不把 fairness、多队列治理做进 `kube-scheduler`；
@@ -152,9 +160,9 @@ sequenceDiagram
 
 ## 事实校对
 
-截至 **2026-07-11**：
+截至 **2026-07-24**：
 
-- `Kueue` 最新 release 为 `v0.18.3`，发布时间为 `2026-07-10`。
+- `Kueue` 最新 release 为 `v0.19.0`，发布时间为 `2026-07-22`。
 - `JobSet` 最新 release 为 `v0.12.0`，发布时间为 `2026-05-08`。
 - `KubeRay` 最新 release 为 `v1.6.2`，发布时间为 `2026-06-18`。
 - `KEP-4671 Gang Scheduling` 状态为 `implementable`，stage 标记为 `beta`。

--- a/docs/blog/2026-05-04/2026-05-04-large-scale-gpu-scheduling-topology-queue-fairness_zh.md
+++ b/docs/blog/2026-05-04/2026-05-04-large-scale-gpu-scheduling-topology-queue-fairness_zh.md
@@ -2,7 +2,7 @@
 status: Draft
 maintainer: pacoxu
 date: 2026-05-04
-last_updated: 2026-07-13
+last_updated: 2026-07-24
 tags: kubernetes, gpu, scheduling, dra, kueue, volcano, koordinator, hami
 canonical_path: docs/blog/2026-05-04/2026-05-04-large-scale-gpu-scheduling-topology-queue-fairness_zh.md
 source_urls:
@@ -15,7 +15,9 @@ source_urls:
   - https://kueue.sigs.k8s.io/docs/overview/
   - https://kueue.sigs.k8s.io/docs/tasks/run/dra/
   - https://kueue.sigs.k8s.io/docs/concepts/multikueue/
+  - https://github.com/kubernetes-sigs/kueue/releases/tag/v0.19.0
   - https://github.com/kai-scheduler/KAI-Scheduler
+  - https://github.com/kai-scheduler/KAI-Scheduler/releases/tag/v0.16.6
   - https://github.com/volcano-sh/volcano/releases/tag/v1.15.0
   - https://github.com/koordinator-sh/koordinator/releases/tag/v1.8.0
   - https://github.com/Project-HAMi/HAMi/releases/tag/v2.9.0
@@ -136,12 +138,15 @@ sequenceDiagram
 
 ## 事实校对
 
-校对时间：2026-07-13。
+校对时间：2026-07-24。
 
 - Kubernetes DRA：官方文档标记为 v1.35 stable；v1.36 继续加入 prioritized list stable、AdminAccess stable，以及分区设备、device taints、ResourceHealth、扩展资源兼容等 beta/alpha 能力。
 - Kubernetes workload-aware scheduling：PodGroup、Gang Scheduling、Topology-Aware Workload Scheduling、Workload-Aware Preemption 在 v1.35/v1.36 仍以 alpha 为主，生产使用需要关注 feature gate 和 API 变化。
-- Kueue：latest release 为 v0.18.3，文档覆盖 Fair Sharing、Cohort、preemption、DRA quota、MultiKueue、Topology-Aware Scheduling 等能力；Kueue 不替换底层调度器。
-- KAI Scheduler：latest release 为 v0.16.4，项目定位是面向大规模 AI/GPU 集群的 Kubernetes native scheduler，强调 hierarchical queues、fairness、DRA、topology-aware scheduling 和 GPU sharing。
+- Kueue：latest release 为 v0.19.0，文档覆盖 Fair Sharing、Cohort、preemption、
+  DRA quota、MultiKueue、Topology-Aware Scheduling 等能力；Kueue 不替换底层调度器。
+- KAI Scheduler：latest release 为 v0.16.6，项目定位是面向大规模 AI/GPU 集群的
+  Kubernetes native scheduler，强调 hierarchical queues、fairness、DRA、
+  topology-aware scheduling 和 GPU sharing。
 - Volcano：latest release 为 v1.15.0，包含 gang-aware preemption、资源回收、DRA queue quota、multi-sharding、Kubernetes 1.35 支持等调度增强。
 - Koordinator：latest release 为 v1.8.0，关注混部、资源画像、DeviceShare、Coscheduling、NUMA/topology、reservation、preemption 和调度诊断。
 - HAMi：latest release 为 v2.9.0，继续推进 HAMi-core、HAMi-DRA、Volcano vGPU device plugin、Ascend 910C 支持、quota webhook 和 metrics。

--- a/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks.md
+++ b/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks.md
@@ -2,6 +2,7 @@
 status: Active
 maintainer: pacoxu
 date: 2026-05-13
+last_updated: 2026-07-24
 tags: inference, orchestration, kubernetes, llm, pd-disaggregation, llm-d, kserve, dynamo, aibrix, kthena, sglang, rbg, vllm
 canonical_path: docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks.md
 source_urls:
@@ -11,17 +12,20 @@ source_urls:
   - https://kserve.github.io/website/blog/cloud-native-ai-inference-kserve-llm-d
   - https://github.com/llm-d/llm-d
   - https://github.com/llm-d/llm-d/releases
+  - https://github.com/llm-d/llm-d/releases/tag/v0.8.1
   - https://llm-d.ai/docs/architecture/architecture
   - https://github.com/vllm-project/production-stack
   - https://github.com/vllm-project/production-stack/releases
   - https://docs.vllm.ai/en/latest/deployment/integrations/production-stack.html
   - https://github.com/vllm-project/aibrix
   - https://github.com/vllm-project/aibrix/releases
+  - https://github.com/vllm-project/aibrix/releases/tag/v0.7.0
   - https://aibrix.readthedocs.io/latest/getting_started/installation/installation.html
   - https://aibrix.readthedocs.io/latest/designs/aibrix-stormservice.html
   - https://aibrix.readthedocs.io/latest/designs/aibrix-router.html
   - https://aibrix.readthedocs.io/latest/features/autoscaling/metric-based-autoscaling.html
   - https://kthena.volcano.sh/docs/intro
+  - https://github.com/volcano-sh/kthena/releases/tag/v1.0.0
   - https://kthena.volcano.sh/docs/v0.2.0/architecture
   - https://github.com/volcano-sh/kthena/blob/main/docs/proposal/modelserving-role-support-leaderworkerset.md
   - https://github.com/volcano-sh/kthena/pull/767
@@ -115,7 +119,7 @@ This combination aligns with environments already centered on standard Kubernete
 
 `llm-d` is currently best understood as a **Kubernetes-native distributed inference serving stack**, not as a general platform and not merely as a `vLLM` deployment template.
 
-As of `v0.7.0` on **2026-05-12**, the public release notes and architecture docs show a fairly complete direction:
+As of `v0.8.1` on **2026-06-26**, the public release notes and architecture docs show a fairly complete direction:
 
 - Router and Scheduler as first-class components
 - KV cache aware routing
@@ -213,7 +217,7 @@ Placed next to `RBG`, the difference is fairly clear:
 
 `AIBrix` presents a modular platform rather than a single-CRD design.
 
-As of `v0.6.0` on **2026-03-03** and the latest public docs, the main signals are:
+As of `v0.7.0` on **2026-06-18** and the latest public docs, the main signals are:
 
 - vanilla Kubernetes is a first-class path
 - `Envoy Gateway` is a required entry layer
@@ -245,8 +249,7 @@ Its main value is not support for one specific workload shape, but rather the wa
 - `ModelRoute`
 - `ModelServer`
 - `ModelServing`
-- `AutoScalingPolicy`
-- `AutoScalingPolicyBinding`
+- `AutoscalingPolicy`
 
 From the current docs and official blog, several characteristics are stable:
 
@@ -255,7 +258,12 @@ From the current docs and official blog, several characteristics are stable:
 - request-level intelligent routing
 - token-based rate limiting, canary, and failover
 - role-aware PD routing
-- multi-metric, cost-driven autoscaling
+- coordinated role-level P/D autoscaling with optional replica-ratio constraints
+- session boost for multi-turn workloads and cache-aware router metrics
+
+Kthena v1.0.0 removed `AutoscalingPolicyBinding`; existing autoscaling targets
+must move into `AutoscalingPolicy.spec.homogeneousTarget`,
+`heterogeneousTarget`, or `disaggregatedTarget` before upgrading.
 
 At the same time, public proposals and follow-up PRs show ongoing exploration of **LWS API compatibility**. That places LWS more as a compatible northbound interface than as the only internal primitive.
 

--- a/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks_zh.md
+++ b/docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks_zh.md
@@ -2,6 +2,7 @@
 status: Active
 maintainer: pacoxu
 date: 2026-05-13
+last_updated: 2026-07-24
 tags: inference, orchestration, kubernetes, llm, pd-disaggregation, llm-d, kserve, dynamo, aibrix, kthena, sglang, rbg, vllm
 canonical_path: docs/blog/2026-05-13/2026-05-13-how-to-choose-inference-orchestration-stacks_zh.md
 source_urls:
@@ -11,17 +12,20 @@ source_urls:
   - https://kserve.github.io/website/blog/cloud-native-ai-inference-kserve-llm-d
   - https://github.com/llm-d/llm-d
   - https://github.com/llm-d/llm-d/releases
+  - https://github.com/llm-d/llm-d/releases/tag/v0.8.1
   - https://llm-d.ai/docs/architecture/architecture
   - https://github.com/vllm-project/production-stack
   - https://github.com/vllm-project/production-stack/releases
   - https://docs.vllm.ai/en/latest/deployment/integrations/production-stack.html
   - https://github.com/vllm-project/aibrix
   - https://github.com/vllm-project/aibrix/releases
+  - https://github.com/vllm-project/aibrix/releases/tag/v0.7.0
   - https://aibrix.readthedocs.io/latest/getting_started/installation/installation.html
   - https://aibrix.readthedocs.io/latest/designs/aibrix-stormservice.html
   - https://aibrix.readthedocs.io/latest/designs/aibrix-router.html
   - https://aibrix.readthedocs.io/latest/features/autoscaling/metric-based-autoscaling.html
   - https://kthena.volcano.sh/docs/intro
+  - https://github.com/volcano-sh/kthena/releases/tag/v1.0.0
   - https://kthena.volcano.sh/docs/v0.2.0/architecture
   - https://github.com/volcano-sh/kthena/blob/main/docs/proposal/modelserving-role-support-leaderworkerset.md
   - https://github.com/volcano-sh/kthena/pull/767
@@ -115,7 +119,7 @@ source_urls:
 
 `llm-d` 当前更接近 **Kubernetes-native distributed inference serving stack**，而不是通用平台，也不是单纯的 `vLLM` 部署模板。
 
-截至 `2026-05-12` 发布的 `v0.7.0`，公开材料显示它的主线已经比较完整：
+截至 `2026-06-26` 发布的 `v0.8.1`，公开材料显示它的主线已经比较完整：
 
 - Router / Scheduler 作为一等组件
 - KV cache aware routing
@@ -215,7 +219,7 @@ SGLang 当前同时覆盖 runtime 与 gateway。
 
 `AIBrix` 当前呈现为模块化平台设计，而不是单一 CRD。
 
-截至 `2026-03-03` 的 `v0.6.0` 与最新文档，公开信号包括：
+截至 `2026-06-18` 的 `v0.7.0` 与最新文档，公开信号包括：
 
 - vanilla Kubernetes 是一条明确路径
 - `Envoy Gateway` 是前置依赖
@@ -247,8 +251,7 @@ Kthena 当前已经明确把自己定位成 **Kubernetes-native AI serving platf
 - `ModelRoute`
 - `ModelServer`
 - `ModelServing`
-- `AutoScalingPolicy`
-- `AutoScalingPolicyBinding`
+- `AutoscalingPolicy`
 
 从当前文档与官方博客看，Kthena 的几个特点比较稳定：
 
@@ -257,7 +260,12 @@ Kthena 当前已经明确把自己定位成 **Kubernetes-native AI serving platf
 - request-level intelligent routing
 - token-based rate limit、canary、failover
 - role-aware PD routing
-- 多指标、成本驱动 autoscaling
+- 支持可选副本比例约束的 P/D role-level 协同 autoscaling
+- 面向多轮会话的 session boost 与 cache-aware router 指标
+
+Kthena `v1.0.0` 已移除 `AutoscalingPolicyBinding`；升级前需要把目标配置迁移到
+`AutoscalingPolicy.spec.homogeneousTarget`、`heterogeneousTarget` 或
+`disaggregatedTarget`。
 
 同时，公开 proposal 与后续 PR 也显示，Kthena 正在探索 **LWS API compatibility**。因此，LWS 在其中更接近兼容的 northbound 接口，而不是唯一底层 primitive。
 

--- a/docs/blog/2026-05-18/2026-05-18-model-streamer-modelexpress-model-loading-zh.md
+++ b/docs/blog/2026-05-18/2026-05-18-model-streamer-modelexpress-model-loading-zh.md
@@ -2,7 +2,7 @@
 status: Active
 maintainer: pacoxu
 date: 2026-05-18
-last_updated: 2026-07-16
+last_updated: 2026-07-24
 tags: model-loading, cold-start, runai-model-streamer, modelexpress, dynamo, vllm, kubernetes
 canonical_path: docs/blog/2026-05-18/2026-05-18-model-streamer-modelexpress-model-loading-zh.md
 source_urls:
@@ -10,6 +10,7 @@ source_urls:
   - https://github.com/run-ai/runai-model-streamer
   - https://docs.vllm.ai/en/stable/models/extensions/runai_model_streamer/
   - https://github.com/ai-dynamo/modelexpress
+  - https://github.com/ai-dynamo/dynamo/releases/tag/v1.3.0
   - https://docs.nvidia.com/dynamo/latest/kubernetes-deployment/model-loading/model-express
   - https://cloud.google.com/blog/products/containers-kubernetes/nvidia-runai-model-streamer-supports-cloud-storage
 ---
@@ -148,7 +149,8 @@ ModelExpress 并不是模型 registry，也不是 KV Cache 管理器。它解决
 “谁已经有这份权重、下一副本从哪里拿最快”。没有 source 时仍要回退到存储；这正是
 它与 Model Streamer 可以组合的原因。
 
-Dynamo 当前文档推荐在较新的 ModelExpress/runtime 镜像中使用统一的 `mx` loader：
+Dynamo `v1.3.0` release notes 已把 vLLM 的 ModelExpress 入口统一到插件维护的
+`modelexpress` loader：
 
 ```yaml
 services:
@@ -161,7 +163,7 @@ services:
           - --model
           - meta-llama/Llama-3.1-70B-Instruct
           - --load-format
-          - mx
+          - modelexpress
         env:
           - name: VLLM_PLUGINS
             value: modelexpress
@@ -171,20 +173,22 @@ services:
             value: "8"
 ```
 
-平台安装时可通过 Dynamo Operator 的 `modelExpressURL` 配置把
-`MODEL_EXPRESS_URL` 注入 worker。旧镜像可能仍暴露 `mx-source`/`mx-target`，因此升级
-时必须以 runtime image 与 ModelExpress 版本的实际支持矩阵为准。
+Dynamo `v1.3.0` 同时移除了旧的 `--model-express-url` / `MODEL_EXPRESS_URL`
+配置，ModelExpress server 的发现由插件路径处理。需要注意，发布后在线文档仍有页面展示
+`mx`、`modelExpressURL` 和 `MODEL_EXPRESS_URL`，与 `v1.3.0` release notes 存在时间差；
+部署时应以 runtime image 内的插件版本和 `--help` 输出为最终依据。旧镜像还可能暴露
+`mx`、`mx-source` 或 `mx-target`，不能跨版本直接复用配置。
 
 如果 ModelExpress server 使用 RWO PVC、与 worker 不共享文件系统，或集群没有可用的
 RDMA fabric，可设置 `MODEL_EXPRESS_NO_SHARED_STORAGE=1`，让客户端从 server 通过 gRPC
 流式读取。这提供了回退路径，但官方文档也明确指出，共享文件系统可用时通常更快。
 
-### 版本与特性阶段（校对至 2026-07-16）
+### 版本与特性阶段（校对至 2026-07-24）
 
 - Run:ai Model Streamer 仓库的最新 release 是 `v0.16.1`（2026-07-13）。
-- NVIDIA Dynamo 在线文档当前标记的 latest 版本是 `v1.2.1`。
-- ModelExpress `v0.3+` 文档使用统一的 `mx` loader；旧 runtime image 可能仍使用
-  `mx-source`/`mx-target`。
+- NVIDIA Dynamo 当前 latest release 与在线文档版本均为 `v1.3.0`（2026-07-22）。
+- Dynamo `v1.3.0` release notes 使用 `modelexpress` loader 并移除旧 URL 配置；
+  部分在线页面仍展示 `mx`，升级时需要按实际 runtime image 校验。
 - vLLM stable 文档已列出 `runai_streamer` 与 `runai_streamer_sharded`，但具体对象存储
   SDK、设备与分布式加载能力仍应以部署镜像内的实际依赖版本为准。
 

--- a/docs/inference/README.md
+++ b/docs/inference/README.md
@@ -152,8 +152,8 @@ For detailed information, see
 inference platform that transforms how organizations deploy and manage Large
 Language Models in production. Kthena is part of the Volcano ecosystem and
 provides comprehensive infrastructure for scalable LLM inference. **Latest
-release: v0.3.0** introduces LeaderWorkerSet support, network topology-aware
-scheduling, and enhanced observability.
+release: v1.0.0** adds coordinated role-level P/D autoscaling, session-aware
+routing, safer role-level rolling updates, and richer cache-aware observability.
 
 **Key highlights:**
 
@@ -166,6 +166,9 @@ scheduling, and enhanced observability.
 - **Router Observability**: Comprehensive metrics, debug port, and E2E testing
   for production reliability
 - **Enhanced Rolling Updates**: Configurable maxUnavailable for faster rollouts
+- **Coordinated P/D Autoscaling**: Independent role metrics with optional
+  prefill/decode replica-ratio constraints
+- **Session Boost**: Prioritizes follow-up requests to improve warm KV-cache reuse
 - **Plugin Framework**: Extensible architecture for custom configuration logic
 - **vLLM Data Parallel**: Support for vLLM data parallel deployment modes
 

--- a/docs/inference/aibrix.md
+++ b/docs/inference/aibrix.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-04-06
+last_updated: 2026-07-24
 tags: inference, aibrix, vllm, llm-serving, lora
 canonical_path: docs/inference/aibrix.md
 ---
@@ -63,7 +63,7 @@ to provide a comprehensive LLM inference platform:
 
 ## Project Status
 
-- **Current Version**: v0.6.0 (as of March 2026)
+- **Current Version**: v0.7.0 (as of June 2026)
 - **License**: Apache 2.0
 - **Maturity**: Active development with regular releases
 - **Community**: Part of vLLM project with dedicated Slack channel
@@ -73,7 +73,7 @@ to provide a comprehensive LLM inference platform:
 AIBrix v0.4.0 introduced comprehensive Prefill/Decode (P/D) disaggregation
 support with StormService and RoleSet CRDs to enable fine-grained
 orchestration of P/D roles, along with routing to unlock disaggregated
-inference at scale. These capabilities are now part of the current v0.6.0
+inference at scale. These capabilities are now part of the current v0.7.0
 release line.
 
 Key features include:
@@ -95,7 +95,7 @@ For more details, see [PD Disaggregation](./pd-disaggregation.md).
 
 ```bash
 # Install component dependencies
-AIBRIX_VERSION="v0.6.0"
+AIBRIX_VERSION="v0.7.0"
 GITHUB_BASE="https://github.com/vllm-project/aibrix/releases/download"
 kubectl apply -f \
   "${GITHUB_BASE}/${AIBRIX_VERSION}/aibrix-dependency-${AIBRIX_VERSION}.yaml" \

--- a/docs/inference/model-lifecycle.md
+++ b/docs/inference/model-lifecycle.md
@@ -505,7 +505,8 @@ multi-model lifecycle management:
 Kubernetes-based platforms for model lifecycle management:
 
 - **Kthena**: Volcano-based LLM inference platform with ModelServing revision
-  control, rolling updates, and plugin framework (v0.3.0+)
+  control, role-level rolling updates, coordinated P/D autoscaling, and
+  session-aware routing (v1.0.0+)
 - **Kubeflow**: Comprehensive ML platform with model serving
 
 ---

--- a/docs/inference/pd-disaggregation.md
+++ b/docs/inference/pd-disaggregation.md
@@ -515,9 +515,9 @@ management and multi-tenancy support.
 Kubernetes-native LLM inference platform that provides comprehensive
 infrastructure for deploying and managing Large Language Models in production
 environments. As part of the Volcano ecosystem, Kthena brings enterprise-grade
-capabilities to LLM inference workloads. **Latest release: v0.3.0** establishes
-Kthena as a robust and scalable platform for AI inference with significant
-enhancements for P/D disaggregation.
+capabilities to LLM inference workloads. **Latest release: v1.0.0** strengthens
+production P/D disaggregation with coordinated role-level autoscaling,
+session-aware routing, and safer rolling updates.
 
 **Key Capabilities:**
 
@@ -530,7 +530,7 @@ enhancements for P/D disaggregation.
 - **Workload Orchestration**: Comprehensive lifecycle management for inference
   workloads including scaling and failure handling
 
-**v0.3.0 New Features for P/D Disaggregation:**
+**P/D Disaggregation Features:**
 
 - **LeaderWorkerSet Support**: Native integration with LeaderWorkerSet (LWS)
   API enables sophisticated management of distributed inference workloads with
@@ -548,6 +548,11 @@ enhancements for P/D disaggregation.
 - **Router Observability**: Comprehensive observability framework with debug
   port (default 15000), detailed metrics for monitoring latency/throughput,
   and E2E test suite for production reliability
+- **Coordinated P/D Autoscaling**: `AutoscalingPolicy.spec.disaggregatedTarget`
+  lets prefill and decode roles scale from separate metrics while optional
+  ratio constraints keep the deployment balanced
+- **Session Boost**: Prioritizes follow-up requests from recent sessions to
+  improve the chance of reusing warm KV cache
 
 **Integration with P/D Disaggregation:**
 
@@ -564,7 +569,7 @@ Kthena provides infrastructure support for P/D disaggregation through:
 
 **Production Advantages:**
 
-With v0.3.0, Kthena is particularly well-suited for organizations building
+With v1.0.0, Kthena is particularly well-suited for organizations building
 production LLM inference platforms with P/D disaggregation requirements:
 
 - Network topology awareness significantly reduces communication overhead
@@ -572,6 +577,11 @@ production LLM inference platforms with P/D disaggregation requirements:
 - Role-level gang scheduling ensures atomic deployment of distributed workloads
 - Comprehensive observability enables production monitoring and debugging
 - Native revision control supports safe canary deployments and rollbacks
+
+The v1.0.0 autoscaling API is not backward compatible:
+`AutoscalingPolicyBinding` was removed. Existing targets must move into
+`AutoscalingPolicy.spec.homogeneousTarget`, `heterogeneousTarget`, or
+`disaggregatedTarget` before upgrading.
 
 ### llm-d
 

--- a/project_watchlist.json
+++ b/project_watchlist.json
@@ -5,6 +5,10 @@
       "url": "https://github.com/ai-dynamo/dynamo"
     },
     {
+      "repo": "ai-dynamo/modelexpress",
+      "url": "https://github.com/ai-dynamo/modelexpress"
+    },
+    {
       "repo": "agent-substrate/substrate",
       "url": "https://github.com/agent-substrate/substrate"
     },
@@ -105,6 +109,10 @@
       "url": "https://github.com/kagent-dev/kagent"
     },
     {
+      "repo": "kai-scheduler/KAI-Scheduler",
+      "url": "https://github.com/kai-scheduler/KAI-Scheduler"
+    },
+    {
       "repo": "kaito-project/kaito",
       "url": "https://github.com/kaito-project/kaito"
     },
@@ -115,6 +123,10 @@
     {
       "repo": "kong/kong",
       "url": "https://github.com/kong/kong"
+    },
+    {
+      "repo": "koordinator-sh/koordinator",
+      "url": "https://github.com/koordinator-sh/koordinator"
     },
     {
       "repo": "kserve/kserve",
@@ -139,6 +151,14 @@
     {
       "repo": "kubernetes-sigs/inference-perf",
       "url": "https://github.com/kubernetes-sigs/inference-perf"
+    },
+    {
+      "repo": "kubernetes-sigs/jobset",
+      "url": "https://github.com/kubernetes-sigs/jobset"
+    },
+    {
+      "repo": "kubernetes-sigs/kueue",
+      "url": "https://github.com/kubernetes-sigs/kueue"
     },
     {
       "repo": "kvcache-ai/mooncake",
@@ -209,6 +229,10 @@
       "url": "https://github.com/polyaxon/polyaxon"
     },
     {
+      "repo": "Project-HAMi/HAMi",
+      "url": "https://github.com/Project-HAMi/HAMi"
+    },
+    {
       "repo": "pytorch/pytorch",
       "url": "https://github.com/pytorch/pytorch"
     },
@@ -217,8 +241,16 @@
       "url": "https://github.com/qdrant/qdrant"
     },
     {
+      "repo": "ray-project/kuberay",
+      "url": "https://github.com/ray-project/kuberay"
+    },
+    {
       "repo": "ray-project/ray",
       "url": "https://github.com/ray-project/ray"
+    },
+    {
+      "repo": "run-ai/runai-model-streamer",
+      "url": "https://github.com/run-ai/runai-model-streamer"
     },
     {
       "repo": "seldonio/seldon-core",
@@ -263,6 +295,14 @@
     {
       "repo": "vllm-project/vllm",
       "url": "https://github.com/vllm-project/vllm"
+    },
+    {
+      "repo": "volcano-sh/kthena",
+      "url": "https://github.com/volcano-sh/kthena"
+    },
+    {
+      "repo": "volcano-sh/volcano",
+      "url": "https://github.com/volcano-sh/volcano"
     },
     {
       "repo": "volcengine/verl",


### PR DESCRIPTION
## What changed

- update Kueue references to v0.19.0 and document quota, `WaitForPodsReady`, API, and integration migration considerations
- update Dynamo/ModelExpress guidance for the v1.3.0 loader contract and call out the temporary mismatch between release notes and generated online docs
- refresh Kthena to v1.0.0, including the removal of `AutoscalingPolicyBinding` and new coordinated P/D autoscaling behavior
- refresh llm-d to v0.8.1, AIBrix to v0.7.0, and KAI Scheduler to v0.16.6
- add the actively referenced scheduling and model-loading repositories to `project_watchlist.json`

## Why

Several active guides contained explicit “latest release” claims that became stale after upstream releases in June and July 2026. Some changes are operationally significant: Kueue v0.19.0 changes Ray sidecar quota accounting and defaults, Kthena v1.0.0 removes an autoscaling API, and Dynamo v1.3.0 changes the ModelExpress loader contract.

## Impact

Readers get current version references and upgrade notes instead of copying configurations or APIs that may no longer work with current images and CRDs. The expanded watchlist makes future release drift easier to detect.

## Validation

- `git diff --check`
- `jq empty project_watchlist.json`
- verified 79 included watchlist repositories are unique
- Markdown lint passes for all modified Markdown files with MD013 disabled; the repository already contains pre-existing long-line MD013 findings in these documents
- checked upstream release metadata and release notes for Kueue, Dynamo, Kthena, llm-d, AIBrix, KAI Scheduler, JobSet, KubeRay, Volcano, Koordinator, HAMi, and vLLM Production Stack