### PR TITLE
docs: add K8E to agent sandbox landscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-08-21
+last_updated: 2026-08-25
 tags: ai-infrastructure, kubernetes, learning-path, landscape
 ---
 
@@ -291,6 +291,9 @@ can perceive, reason, and act.
       collaborative AI with federated learning
     - [`Kubernetes SIG Agent Sandbox`](https://github.com/kubernetes-sigs/agent-sandbox):
       Secure sandbox for AI agents
+    - [`K8E`](https://github.com/xiaods/k8e): Self-hosted, single-binary
+      Kubernetes sandbox distribution with warm pools and pluggable gVisor,
+      Kata Containers, or Firecracker isolation
     - [`Agent Substrate`](https://github.com/agent-substrate/substrate):
       Core system and high-density Kubernetes runtime for stateful agent actors with
       suspend/resume and real-time routing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-08-21
+last_updated: 2026-08-25
 tags: ai-infrastructure, kubernetes, learning-path, landscape
 ---
 
@@ -281,6 +281,9 @@ AI 网关为 LLM API 提供路由、负载均衡和管理，
     - [`KubeEdge Sedna`](https://github.com/kubeedge/sedna): 边云协同 AI 与联邦学习
     - [`Kubernetes SIG Agent Sandbox`](https://github.com/kubernetes-sigs/agent-sandbox):
       AI 智能体的安全沙箱
+    - [`K8E`](https://github.com/xiaods/k8e): 自托管、单二进制的
+      Kubernetes 沙箱发行版，提供 Warm Pool，并可接入 gVisor、
+      Kata Containers 或 Firecracker 隔离
     - [`Agent Substrate`](https://github.com/agent-substrate/substrate):
       面向有状态智能体会话的核心系统和高密度 Kubernetes 运行时，支持
       suspend/resume 与实时流量路由

--- a/agent-infra/README.md
+++ b/agent-infra/README.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-07-09
+last_updated: 2026-08-25
 tags: ai-agents, agentic-workflow, kubernetes, mcp, agent-platforms
 canonical_path: agent-infra/README.md
 ---
@@ -242,6 +242,44 @@ running AI agents with strong isolation guarantees.
 
 See also: [Agent Sandbox Documentation](../docs/kubernetes/isolation.md#6-agent-sandbox-kubernetes-sig-project)
 
+### K8E
+
+<a href="https://github.com/xiaods/k8e">`xiaods/k8e`</a>
+
+K8E is a self-hosted agent sandbox distribution that packages a lightweight
+Kubernetes cluster, a sandbox gateway, warm-pool management, and runtime
+integration into a single binary. It spans several layers that are normally
+assembled separately: the cluster distribution, agent-facing sandbox
+operations, Kubernetes lifecycle management, network policy, and pluggable
+isolation runtimes.
+
+**Key Features:**
+
+- Single-binary installation for a Kubernetes-based sandbox cluster
+- Warm pools for low-latency session allocation
+- gVisor, Kata Containers, and Firecracker runtime integration
+- Per-session Cilium eBPF egress policy and resource governance
+- CLI and E2B-compatible API surfaces for session, command, file, terminal,
+  and snapshot operations
+- Compatibility with `kubernetes-sigs/agent-sandbox`
+
+**Status**: Active Apache-2.0 project. The integrated agent-sandbox surface is
+evolving quickly; validate its security model, runtime compatibility, upgrade
+path, and performance against your own production requirements.
+
+**Use Cases:**
+
+- Teams that want a self-contained Kubernetes sandbox appliance instead of
+  assembling the cluster, gateway, warm pool, networking, and runtimes
+  independently
+- Private agent execution clusters with multiple isolation profiles
+- Coding-agent or tool-execution services that need ephemeral workspaces,
+  audited operations, and fast session claims
+
+K8E should not be compared one-for-one with a single CRD controller or a
+single isolation runtime. It is an integrated distribution that composes both
+layers and can consume `kubernetes-sigs/agent-sandbox` APIs.
+
 ### Agent Substrate
 
 <a href="https://github.com/agent-substrate/substrate">`agent-substrate/substrate`</a>
@@ -391,7 +429,7 @@ APIs around existing CRDs/runtime backends, but watch `pods/dynamic` because it
 could eventually collapse some custom fast-start paths back into core
 Kubernetes.
 
-#### Agent Sandbox Selection Update (2026-07-09)
+#### Agent Sandbox Selection Update (2026-08-25)
 
 Recent agent sandbox projects should be compared by layer, not as direct
 one-for-one replacements. A practical platform usually combines an
@@ -402,6 +440,7 @@ runtimes:
 | ----- | ------------------ | ------------ | --------------- |
 | Agent-facing sandbox platform | [OpenSandbox](https://github.com/alibaba/OpenSandbox), [CubeSandbox](https://github.com/TencentCloud/CubeSandbox), [E2B](https://github.com/e2b-dev/e2b), [Daytona](https://github.com/daytonaio/daytona), [Sandbox0](https://github.com/sandbox0-ai/sandbox0) | SDK/API, sandbox lifecycle, command/file/browser execution, templates | Use OpenSandbox as the broad self-hosted default; evaluate CubeSandbox for high-density E2B-compatible microVM pools; check Daytona's AGPLv3 impact before embedding. |
 | Kubernetes lifecycle API | [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox), [agent-sandbox/agent-sandbox](https://github.com/agent-sandbox/agent-sandbox), [volcano-sh/agentcube](https://github.com/volcano-sh/agentcube) | CRD/controller, warm pools, stable sandbox identity, scheduling hooks | `kubernetes-sigs/agent-sandbox` is the neutral K8s API layer; `agent-sandbox/agent-sandbox` adds REST/MCP and E2B compatibility; AgentCube is still proposal/early design. |
+| Integrated Kubernetes sandbox distribution | [K8E](https://github.com/xiaods/k8e) | Single-binary cluster, sandbox gateway, warm pools, network policy, and runtime integration | Evaluate when a self-contained sandbox appliance is preferable to assembling each layer. Treat its sub-500ms warm-pool claim and other performance figures as project-reported until reproduced in your environment. |
 | Agent runtime substrate | [agent-substrate/substrate](https://github.com/agent-substrate/substrate) | Invocation routing, worker pools, agent actor lifecycle, suspend/resume | Use when agent fleets are mostly idle and dedicated pods would waste resources; pair it with Agent Sandbox or runtime sandboxing for the isolation boundary. |
 | Isolation runtime | [gVisor](https://github.com/google/gvisor), [Kata Containers](https://github.com/kata-containers/kata-containers), [containerd/nerdbox](https://github.com/containerd/nerdbox), [Firecracker](https://github.com/firecracker-microvm/firecracker), [Kuasar](https://github.com/kuasar-io/kuasar) | Runtime boundary for untrusted code | Start with gVisor for density and operational simplicity; use Kata for VM-level tenant boundaries and GPU paths; treat Firecracker as a low-level primitive unless the team owns the control plane. |
 | Local coding-agent sandbox | [Cleanroom](https://github.com/buildkite/cleanroom), [Brood Box](https://github.com/stacklok/brood-box), [microsandbox](https://github.com/superradcompany/microsandbox), [BoxLite](https://github.com/boxlite-ai/boxlite), [Matchlock](https://github.com/jingkaihe/matchlock), [Shuru](https://github.com/superhq-ai/shuru), [sandbox-runtime](https://github.com/anthropic-experimental/sandbox-runtime) | Developer-machine isolation, repo policy, credential proxy, diff review | Prefer Cleanroom/Brood Box when the threat model is coding-agent access to a repo; use microsandbox/BoxLite for embeddable local microVM APIs; use sandbox-runtime for OS policy guardrails without VM isolation. |
@@ -431,6 +470,12 @@ Default stack recommendation:
 5. **High-risk runtime**: Kata or CubeSandbox for stronger microVM boundaries.
 6. **Local development**: Cleanroom or Brood Box for repo-scoped egress,
    host-side credentials, and post-run change review.
+
+Integrated alternative: evaluate K8E when the operational goal is a dedicated,
+self-hosted sandbox cluster with the gateway, warm pool, Cilium policy, and
+runtime wiring supplied together. Keep the same workload-level threat-model
+review; packaging the layers together does not by itself prove the isolation
+boundary or production SLOs.
 
 ## Agent Development Frameworks
 

--- a/agent-infra/ai-agent-infra-9-layers-zh.md
+++ b/agent-infra/ai-agent-infra-9-layers-zh.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-07-09
+last_updated: 2026-08-25
 tags: ai-agents, agent-infra, llmops, observability, sandbox, memory, governance
 canonical_path: agent-infra/ai-agent-infra-9-layers-zh.md
 ---
@@ -236,6 +236,7 @@ Agent Framework 和 Workflow Engine 要分清：
 | -- | ------ | ---- |
 | Agent-facing API | SDK、文件、命令、浏览器、模板 | OpenSandbox、E2B、CubeSandbox |
 | Kubernetes 生命周期 | CRD、Warm Pool、SandboxClaim、调度 | kubernetes-sigs/agent-sandbox |
+| 一体化 Kubernetes 沙箱发行版 | 集群、Gateway、Warm Pool、网络策略与 Runtime 集成 | K8E |
 | Runtime Boundary | 隔离强度、密度、启动速度、GPU 支持 | runc、gVisor、Kata、Firecracker |
 | 本地开发沙箱 | 仓库访问、凭据代理、出网控制、Diff Review | Cleanroom、Brood Box、microsandbox |
 
@@ -456,7 +457,7 @@ Agent 的成本来自整条链路：
 | L2 | 托管向量库或自建 Qdrant / Milvus |
 | L3 | Prompt Registry 和版本管理 |
 | L4 | LangGraph、CrewAI、AutoGen 或同类框架 |
-| L5 | E2B / OpenSandbox / Kubernetes Sandbox |
+| L5 | E2B / OpenSandbox / K8E / Kubernetes Sandbox |
 | L6 | Checkpoint、Redis、基础长期记忆 |
 | L7 | Golden Set、RAGAS / DeepEval 等评测 |
 | L8 | Langfuse、LangSmith、OpenTelemetry |

--- a/docs/kubernetes/isolation.md
+++ b/docs/kubernetes/isolation.md
@@ -1,7 +1,7 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-07-10
+last_updated: 2026-08-25
 tags: kubernetes, isolation, security, multi-tenancy
 canonical_path: docs/kubernetes/isolation.md
 ---
@@ -494,7 +494,7 @@ Different technologies offer distinct tradeoffs for agent sandboxing:
 | WASM (monty) | 0.06ms | Sandboxed | Limited subset | Custom |
 | Unikernel (Unikraft) | <100ms | Very strong | Improving | Custom |
 
-### Layered Agent Sandbox Selection (2026-04-22)
+### Layered Agent Sandbox Selection (2026-08-25)
 
 Agent sandbox projects now span several layers. For Kubernetes production
 designs, the most important decision is where each project sits in the stack:
@@ -502,6 +502,7 @@ designs, the most important decision is where each project sits in the stack:
 | Layer | Projects | Fit for Kubernetes Isolation |
 | ----- | -------- | ---------------------------- |
 | Kubernetes lifecycle API | [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox), [agent-sandbox/agent-sandbox](https://github.com/agent-sandbox/agent-sandbox), [volcano-sh/agentcube](https://github.com/volcano-sh/agentcube) | Use for `Sandbox` CRDs, warm pools, stable identity, and scheduler integration. This layer still needs a runtime boundary underneath. |
+| Integrated Kubernetes sandbox distribution | [K8E](https://github.com/xiaods/k8e) | Use when a single-binary, self-hosted cluster that bundles a sandbox gateway, warm pools, Cilium policy, and gVisor/Kata/Firecracker integration is preferable to assembling the layers separately. It spans multiple layers and still relies on the selected runtime as the actual isolation boundary. |
 | Agent runtime substrate | [agent-substrate/substrate](https://github.com/agent-substrate/substrate) | Use when the problem is not only isolation, but running large fleets of mostly idle agents through invocation-based wake-up, suspension/resume, and shared worker pools. |
 | Agent sandbox platform | [OpenSandbox](https://github.com/alibaba/OpenSandbox), [CubeSandbox](https://github.com/TencentCloud/CubeSandbox), [E2B](https://github.com/e2b-dev/e2b), [Daytona](https://github.com/daytonaio/daytona), [Sandbox0](https://github.com/sandbox0-ai/sandbox0) | Use for SDK/API, templates, command/file/browser execution, and self-hosted service operations. Validate licensing and deployment model before embedding. |
 | Runtime boundary | [gVisor](https://github.com/google/gvisor), [Kata Containers](https://github.com/kata-containers/kata-containers), [containerd/nerdbox](https://github.com/containerd/nerdbox), [Firecracker](https://github.com/firecracker-microvm/firecracker), [Kuasar](https://github.com/kuasar-io/kuasar) | Use as the actual isolation boundary: gVisor for density, Kata for VM-level isolation, Firecracker for custom microVM control planes, Kuasar for multi-sandbox containerd integration. |
@@ -511,7 +512,9 @@ Recommended Kubernetes shape:
 
 1. Run agent APIs, auth, billing, policy, and observability as regular Pods.
 2. Allocate execution sandboxes through a `Sandbox` CRD or an equivalent
-   platform API.
+   platform API. For a dedicated integrated cluster, evaluate K8E as a
+   distribution that supplies this API surface together with warm pools,
+   networking, and runtime integration.
 3. Select `RuntimeClass` by risk: `runsc`/gVisor for dense CPU-only tasks,
    Kata for high-risk or GPU-capable tenants, and dedicated VM/microVM pools
    for compliance-heavy workloads.


### PR DESCRIPTION
## Summary

- add K8E to the English and Chinese AI Infra learning paths
- document K8E as an integrated Kubernetes sandbox distribution
- update agent sandbox selection matrices and the nine-layer architecture view
- distinguish the bundled distribution from lifecycle APIs and isolation runtimes
- mark project-reported performance claims as requiring independent validation

## Validation

- git diff --check
- markdownlint-cli2 agent-infra/README.md agent-infra/ai-agent-infra-9-layers-zh.md