### PR TITLE
docs: add NVRC, KVCR, and MatrixHub to NVIDIA landscape

### DIFF
--- a/case-study/nvidia.md
+++ b/case-study/nvidia.md
@@ -43,6 +43,7 @@ flowchart LR
 
   subgraph STATE["KV 状态面 / 数据搬运"]
     KVBM["⭐ KVBM<br/>KV Block Manager"]
+    KVCR["KVCR<br/>KV Cache Runner"]
     NIXL["NIXL"]
     NCCL["NCCL"]
   end
@@ -78,11 +79,13 @@ flowchart LR
 
   %% serving / state plane
   DYN --> KVBM
+  DYN -. "KV Router inventory / hints" .-> KVCR
   DYN --> TRT
   DYN --> TRITON
   LLMD -. "社区侧 distributed serving\nPD / KV-aware routing" .-> DYN
   LLMD -. "双 LWS / 社区路径" .-> LWS
   KVBM -. "KV block 生命周期 /\n分层 offload" .-> NIXL
+  KVCR -. "跨层 / 跨节点传输" .-> NIXL
   DYN -. "KV / prefix 传输" .-> NIXL
   TRT -. "可作为 Triton backend\n也可直接使用" .-> TRITON
 
@@ -98,7 +101,7 @@ flowchart LR
   classDef bridge fill:#f5f3ff,stroke:#7c3aed,color:#4c1d95,stroke-width:1.1px;
 
   class KAI,DRA,DYN,GROVE,KVBM star;
-  class GPO,CTK,NVRC,KDP,DCGM,AICR,NVS,TRT,TRITON,NIXL,NCCL normal;
+  class GPO,CTK,NVRC,KDP,DCGM,AICR,NVS,TRT,TRITON,KVCR,NIXL,NCCL normal;
   class LLMD,LWS bridge;
   class K8S,CTD base;
 ```
@@ -108,6 +111,7 @@ flowchart LR
 - [⭐ ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo)
 - [⭐ ai-dynamo/grove](https://github.com/ai-dynamo/grove)
 - [ai-dynamo/nixl](https://github.com/ai-dynamo/nixl)
+- [ai-dynamo/kvcr](https://github.com/ai-dynamo/kvcr) — KV Cache Runner（活跃开发中）
 - [⭐ kai-scheduler/KAI-Scheduler](https://github.com/kai-scheduler/KAI-Scheduler)
 - [⭐ kubernetes-sigs/dra-driver-nvidia-gpu](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu)
 - [NVIDIA/gpu-operator](https://github.com/NVIDIA/gpu-operator)
@@ -127,16 +131,17 @@ flowchart LR
 - [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
 - [containerd/containerd](https://github.com/containerd/containerd)
 
-## 补充主线：Dynamo / Grove / KAI / KVBM
+## 补充主线：Dynamo / Grove / KAI / KVBM / KVCR
 
 这条线现在更适合理解成：
 
 ```text
 Dynamo -> Grove -> KAI Scheduler -> GPU DRA Driver
           \-> KVBM -> NIXL
+          \-> KV Router -> KVCR -> NIXL
 ```
 
-它们不是四个并列竞争项目，而是从推理系统意图一路落到工作负载抽象、调度策略、
+它们不是一组并列竞争项目，而是从推理系统意图一路落到工作负载抽象、调度策略、
 资源模型和 KV 状态面的主链路。
 
 | 组件 | 在图中的位置 | 主要职责 |
@@ -145,10 +150,16 @@ Dynamo -> Grove -> KAI Scheduler -> GPU DRA Driver
 | `Grove` | 多角色工作负载抽象 | 用 `PodCliqueSet / PodGang` 一类 API 把 `prefill / decode / router / worker` 表达成单个 Kubernetes 对象 |
 | `KAI Scheduler` | 调度策略层 | 负责 gang、拓扑感知、层次队列、公平性和 DRA support，把 Grove 的编排意图落成真正的放置决策 |
 | `KVBM` | KV 状态面 | 管理 KV block 生命周期、跨节点复用与 `HBM -> host -> SSD -> remote` 分层 offload，和 `NIXL` 一起构成 Dynamo 的 KV state plane |
+| `KVCR` | KV cache runtime | 根据 KV Router hints 管理本地 DRAM、SSD 和对象存储驻留，通过 NIXL 完成跨层与跨节点传输，并以 KVCR-Guard 提供可选故障恢复能力 |
 
 这里最容易被漏掉的是 `KVBM`：它不是独立 repo，而是 `Dynamo` 内部非常关键的系统层。
 如果不把它画出来，`Dynamo` 看起来就会像“又一个推理部署器”，而不是一个把 KV 生命周期、
 路由和多节点 serving 一起组织起来的平台。
+
+`KVCR` 则是独立仓库中的新方向：把全局 cache inventory 和路由决策留给 KV-aware router，
+自身聚焦本地 cache policy、驻留与数据搬运。它同时强调 framework/router agnostic，当前仍处于
+活跃开发阶段，官方尚不建议用于生产环境；因此这里先把它与 `KVBM` 并列展示，不直接定义为
+替代关系。
 
 ## 与 llm-d 的交叉补充
 
@@ -164,19 +175,20 @@ Dynamo -> Grove -> KAI Scheduler -> GPU DRA Driver
 | 控制面 / serving stack | `Dynamo` | `llm-d` |
 | 多角色 workload API | `Grove` | `LWS`（双 `LeaderWorkerSet` 路径） |
 | 调度与拓扑 | `KAI + GPU DRA Driver`，更强调 GPU / ComputeDomain / fabric 拓扑 | 更偏社区调度生态组合，常与 `KServe`、Gateway API、Kubernetes 原生 workload API 协同 |
-| KV 路径 | `KVBM + NIXL`，把 KV 复用、offload、远端传输做成系统级 state plane | 更强调 KV-aware routing、PD serving 和 serving stack 集成 |
+| KV 路径 | `KVBM / KVCR + NIXL`，把 KV 复用、offload、远端传输做成系统级 state plane | 更强调 KV-aware routing、PD serving 和 serving stack 集成 |
 | 硬件姿态 | 更偏 NVIDIA 一体化优化 | 更偏中立，更容易成为跨厂商 distributed serving 基线 |
 
 所以把 `llm-d` 交叉补进 NVIDIA 全景图的价值，不是说它和 `Dynamo` 是同一项目，而是能把
 两条路线的分层关系看得更清楚：
 
-- NVIDIA 主线的辨识度在 `Grove + KAI Scheduler + GPU DRA Driver + KVBM`
+- NVIDIA 主线的辨识度在 `Grove + KAI Scheduler + GPU DRA Driver + KVBM / KVCR`
 - 社区主线的辨识度在 `llm-d + LWS + KServe / Gateway API` 这类更上游、更中立的组合
 
 ## 生态交叉项目入口
 
 - [llm-d/llm-d](https://github.com/llm-d/llm-d)
-- [Dynamo KVBM design doc](https://github.com/ai-dynamo/dynamo/blob/main/docs/design-docs/kvbm-design.md)
+- [Dynamo KVBM README](https://github.com/ai-dynamo/dynamo/blob/main/lib/bindings/kvbm/README.md)
+- [KVCR design overview](https://github.com/ai-dynamo/kvcr/blob/main/docs/design_overview.md)
 
 ## 延伸阅读
 

--- a/case-study/nvidia.md
+++ b/case-study/nvidia.md
@@ -17,6 +17,7 @@ flowchart LR
   subgraph OPS["GPU 接入与集群运维"]
     GPO["GPU Operator"]
     CTK["NVIDIA Container Toolkit"]
+    NVRC["NVRC<br/>microVM PID 1"]
     KDP["k8s-device-plugin"]
     DCGM["dcgm-exporter"]
     AICR["AI Cluster Runtime (AICR)"]
@@ -55,11 +56,13 @@ flowchart LR
   K8S --> LWS
   K8S --> DYN
   CTD --> CTK
+  CTD -. "Kata Containers<br/>microVM 路径" .-> NVRC
 
   %% ops layer
   GPO --> CTK
   GPO --> KDP
   GPO --> DCGM
+  NVRC -. "启动 GPU 管理守护进程" .-> DCGM
   AICR --> GPO
   GPO -. "集成入口" .-> DRA
 
@@ -95,7 +98,7 @@ flowchart LR
   classDef bridge fill:#f5f3ff,stroke:#7c3aed,color:#4c1d95,stroke-width:1.1px;
 
   class KAI,DRA,DYN,GROVE,KVBM star;
-  class GPO,CTK,KDP,DCGM,AICR,NVS,TRT,TRITON,NIXL,NCCL normal;
+  class GPO,CTK,NVRC,KDP,DCGM,AICR,NVS,TRT,TRITON,NIXL,NCCL normal;
   class LLMD,LWS bridge;
   class K8S,CTD base;
 ```
@@ -111,6 +114,8 @@ flowchart LR
 - [NVIDIA/k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin)
 - [NVIDIA/dcgm-exporter](https://github.com/NVIDIA/dcgm-exporter)
 - [NVIDIA/nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit)
+- [NVIDIA/nvrc](https://github.com/NVIDIA/nvrc) — NVIDIA Runtime Container Init，
+  Kata Containers GPU microVM 内的最小 PID 1
 - [NVIDIA/NVSentinel](https://github.com/NVIDIA/NVSentinel)
 - [NVIDIA/aicr](https://github.com/NVIDIA/aicr)
 - [NVIDIA/TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM)

--- a/docs/inference/caching.md
+++ b/docs/inference/caching.md
@@ -1,8 +1,8 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2025-10-29
-tags: inference, caching, kv-cache, prefix-caching, llm-optimization
+last_updated: 2026-09-02
+tags: inference, caching, kv-cache, prefix-caching, kvcr, llm-optimization
 canonical_path: docs/inference/caching.md
 ---
 
@@ -266,7 +266,27 @@ management within the Dynamo ecosystem.
 - Efficient memory utilization
 
 For architecture details, see the
-[KVBM Architecture Documentation](https://github.com/ai-dynamo/dynamo/blob/main/docs/architecture/kvbm_architecture.md).
+[KVBM README](https://github.com/ai-dynamo/dynamo/blob/main/lib/bindings/kvbm/README.md).
+
+### KV Cache Runner (KVCR)
+
+[`KV Cache Runner (KVCR)`](https://github.com/ai-dynamo/kvcr) treats KV cache as
+a distributed resource spanning memory and storage tiers. A KV-aware router
+maintains the global cache inventory and sends source hints, while each KVCR
+instance manages local residency, policy, and data movement.
+
+**Key Features:**
+
+- Router-guided cache reuse, load balancing, and prefetching
+- Pluggable admission, eviction, placement, and staging policies
+- Cross-tier and peer-to-peer movement through NIXL
+- Optional `KVCR-Guard` for preserving KVCR-owned host memory across engine
+  failures
+- Framework- and router-agnostic integration model
+
+KVCR is under active development and is not yet recommended for production
+use. Treat it as an emerging design alongside Dynamo KVBM, not as a proven
+drop-in replacement.
 
 ### Host Memory Caching
 
@@ -421,7 +441,7 @@ LMCache, and Mooncake.
 
 <!-- markdownlint-disable MD013 -->
 | Feature | NIXL | LMCache | Mooncake |
-|---------|------|---------|----------|
+| --------- | ------ | --------- | ---------- |
 | **Project Type** | Shared prefix caching | Independent prefix caching | Distributed KV cache service |
 | **Primary Use Case** | Cross-request prefix sharing | Long-context TTFT reduction | Distributed storage management |
 | **Caching Scope** | Shared across requests/users | Per-session/service | Cluster-wide distributed |
@@ -485,7 +505,9 @@ Implementation details can be found in the
 - [NIXL GitHub Repository](https://github.com/ai-dynamo/nixl)
 - [LMCache GitHub Repository](https://github.com/LMCache/lmcache)
 - [Mooncake GitHub Repository](https://github.com/kvcache-ai/Mooncake)
-- [Dynamo KVBM Architecture](https://github.com/ai-dynamo/dynamo/blob/main/docs/architecture/kvbm_architecture.md)
+- [Dynamo KVBM README](https://github.com/ai-dynamo/dynamo/blob/main/lib/bindings/kvbm/README.md)
+- [KVCR GitHub Repository](https://github.com/ai-dynamo/kvcr)
+- [KVCR Design Overview](https://github.com/ai-dynamo/kvcr/blob/main/docs/design_overview.md)
 - [SGlang Memory Cache Storage](https://github.com/sgl-project/sglang/tree/9b5f0f64f52033f5965d5b593df5df45c9be8c24/python/sglang/srt/mem_cache/storage)
 - [llm-d Routing Sidecar](https://github.com/llm-d/llm-d-routing-sidecar)
 - [Red Hat DCN Documentation](https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html/deploying_a_distributed_compute_node_dcn_architecture/understanding_dcn)

--- a/docs/inference/dynamo.md
+++ b/docs/inference/dynamo.md
@@ -1,8 +1,8 @@
 ---
 status: Active
 maintainer: pacoxu
-last_updated: 2026-07-16
-tags: inference, dynamo, architecture, kv-cache, routing, grove, nixl, modelexpress, model-streamer, ai-dynamo
+last_updated: 2026-09-02
+tags: inference, dynamo, architecture, kv-cache, routing, grove, nixl, kvcr, modelexpress, model-streamer, ai-dynamo
 canonical_path: docs/inference/dynamo.md
 ---
 
@@ -179,7 +179,7 @@ flowchart TB
 ## End-To-End Request Flow
 
 The official
-[dynamo-flow.md](https://github.com/ai-dynamo/dynamo/blob/main/docs/design-docs/dynamo-flow.md)
+[Dynamo flow diagram](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/assets/img/dynamo-flow.png)
 adds the dynamic view that the panorama alone does not show: how a single
 disaggregated request moves through the system.
 
@@ -280,7 +280,7 @@ guardrails.
 ## KVBM: The Center Of Dynamo's State Plane
 
 The official
-[KVBM design doc](https://github.com/ai-dynamo/dynamo/blob/main/docs/design-docs/kvbm-design.md)
+[KVBM README](https://github.com/ai-dynamo/dynamo/blob/main/lib/bindings/kvbm/README.md)
 makes it clear that KVBM is not just a cache container. It is the state-plane
 orchestration layer that tracks block lifecycle, memory tier placement, and
 cross-node movement.
@@ -324,10 +324,31 @@ KV visibility and transfer portable:
 That is the architectural reason NIXL sits next to KVBM in the panorama rather
 than under the engine layer.
 
+## KVCR: An Emerging Router-Hinted KV Runtime
+
+[`KV Cache Runner (KVCR)`](https://github.com/ai-dynamo/kvcr) explores a newer
+cache-management boundary. The KV-aware router retains the global cache
+inventory and routing view, while each KVCR instance manages its local DRAM,
+SSD, and configured object-storage residency.
+
+KVCR uses router hints to find reusable cache data, applies pluggable admission,
+eviction, placement, and staging policies, and delegates local or peer-to-peer
+movement to NIXL. The optional `KVCR-Guard` process can preserve KVCR-owned DRAM
+after an engine failure and make the committed cache available during restart.
+
+KVCR is designed to be framework- and router-agnostic. Its published integration
+work includes TensorRT-LLM, vLLM, SGLang, Dynamo KV Router, `sgl-router`, and
+`llm-d` routing paths. The repository is still under active development, may
+introduce breaking changes, and is not yet recommended for production use.
+
+KVBM and KVCR therefore belong to the same broad state-plane discussion, but
+should currently be evaluated as distinct, evolving components rather than
+assuming that one is a drop-in replacement for the other.
+
 ## Discovery Plane: How Components Find Workers
 
 The official
-[discovery-plane.svg](https://github.com/ai-dynamo/dynamo/blob/main/docs/assets/img/discovery-plane.svg)
+[discovery-plane.svg](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/assets/img/discovery-plane.svg)
 shows a simple but important split:
 
 - **components** such as `Frontend`, `Router`, and `Planner` need to
@@ -429,6 +450,10 @@ broader inference and post-training platform.
   startup latency, and
   [FlexTensor](https://github.com/ai-dynamo/flextensor) extends model fit by
   streaming tensors between host and GPU memory.
+- **KV cache runtime**:
+  [KVCR](https://github.com/ai-dynamo/kvcr) combines router-provided cache hints,
+  pluggable cache policies, resilient host-memory ownership, and NIXL-backed
+  tier or peer transfers.
 - **Non-LLM coverage**:
   [AITune](https://github.com/ai-dynamo/aitune) expands Dynamo toward generic
   PyTorch inference, especially for bespoke non-LLM models.
@@ -438,7 +463,8 @@ broader inference and post-training platform.
 - Dynamo is a **system layer** for distributed inference, not a standalone
   replacement for model engines.
 - Its most distinctive capabilities sit in the **request plane**, the
-  **state plane** around KVBM and NIXL, and the **control plane** around
+  **state plane** around KVBM, emerging KVCR work, and NIXL, and the
+  **control plane** around
   Planner, Operator, and Grove.
 - The surrounding `ai-dynamo` projects extend Dynamo in three directions:
   **planning**, **Kubernetes orchestration**, and **memory / weight movement**.
@@ -446,8 +472,10 @@ broader inference and post-training platform.
 ## References
 
 - [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo)
-- [Dynamo KVBM Design](https://github.com/ai-dynamo/dynamo/blob/main/docs/design-docs/kvbm-design.md)
-- [Dynamo Discovery Plane SVG](https://github.com/ai-dynamo/dynamo/blob/main/docs/assets/img/discovery-plane.svg)
+- [Dynamo KVBM README](https://github.com/ai-dynamo/dynamo/blob/main/lib/bindings/kvbm/README.md)
+- [ai-dynamo/kvcr](https://github.com/ai-dynamo/kvcr)
+- [KVCR Design Overview](https://github.com/ai-dynamo/kvcr/blob/main/docs/design_overview.md)
+- [Dynamo Discovery Plane SVG](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/assets/img/discovery-plane.svg)
 - [Dynamo Issue #5506: H1 '26 roadmap](https://github.com/ai-dynamo/dynamo/issues/5506)
 - [Dynamo Issue #9208: Toward Dynamo 2.0](https://github.com/ai-dynamo/dynamo/issues/9208)
 - [ai-dynamo/grove](https://github.com/ai-dynamo/grove)


### PR DESCRIPTION
## Summary

- add NVRC to the NVIDIA cloud-native landscape and document its Kata Containers microVM initialization role
- add KV Cache Runner (KVCR) to the NVIDIA and Dynamo KV state-plane landscape
- document KVCR router hints, cache policy, NIXL transfer, KVCR-Guard resilience, and active-development status
- connect MatrixHub to Dynamo as an in-cluster, Hugging Face-compatible model registry and pre-cached model source
- distinguish MatrixHub model distribution from KV cache and runtime-loading responsibilities
- replace moved KVBM and Dynamo documentation links with their current paths

## Validation

- Markdown lint passes for all modified files
- all links pass in `case-study/nvidia.md`
- all links pass in `docs/inference/dynamo.md`
- all new MatrixHub links pass in `docs/inference/model-distribution-stack.md`
- all new KVCR links pass in `docs/inference/caching.md`

Historical external-link checker exceptions remain outside this change: `huggingface.co` and `rdmamojo.com` return Status 0, while the Red Hat documentation URL returns HTTP 403.